### PR TITLE
docs: add docs/ directory and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,13 @@ deno task build
 ## Slash Commands
 
 * `/dl url:<Tweet URL>`
-  Downloads a single Tweet video
+  Downloads one or more Tweet videos (space-separated URLs supported)
+* `/dl-spoiler url:<Tweet URL>`
+  Same as `/dl`, but the resulting file is uploaded as a Discord spoiler attachment
+* `/threaddl name:<Thread Name> url:<Tweet URL>` *(in development)*
+  Will create a thread with the given name and post each download result inside it. Currently registered as a command definition; runtime wiring is being implemented in a separate stream.
+
+See [`docs/commands.md`](./docs/commands.md) for the full command reference.
 
 ---
 
@@ -75,6 +81,18 @@ deno task build
   Start the bot locally
 * `docker/Dockerfile`
   Defines the video processing runner image
+
+---
+
+## Documentation
+
+In-depth documentation lives under [`docs/`](./docs/):
+
+* [`docs/architecture.md`](./docs/architecture.md) — system overview and data flow
+* [`docs/commands.md`](./docs/commands.md) — slash command reference
+* [`docs/development.md`](./docs/development.md) — local setup, env vars, GitHub token scopes
+* [`docs/deployment.md`](./docs/deployment.md) — runner image and bot deployment
+* [`docs/github-actions.md`](./docs/github-actions.md) — `repository_dispatch` payload, callback API, secrets
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,16 @@
+# tw-dl-bot Documentation
+
+This directory contains the developer-facing documentation for **tw-dl-bot**, a Deno + TypeScript Discord bot that downloads videos from Tweets via yt-dlp running in GitHub Actions.
+
+## Contents
+
+- [Architecture](./architecture.md) — High-level system overview and data flow between Discord, the bot, GitHub Actions, and yt-dlp.
+- [Commands](./commands.md) — Reference for the `/dl`, `/dl-spoiler`, and `/threaddl` slash commands.
+- [Development](./development.md) — Local development setup, environment variables, and required GitHub token scopes.
+- [Deployment](./deployment.md) — Deployment workflow, runner image build/publish, and runtime environment.
+- [GitHub Actions](./github-actions.md) — `repository_dispatch` payload schema, callback API, and required secrets.
+
+## See also
+
+- Top-level [README](../README.md) — Project overview, setup, and command list.
+- [LICENSE](../LICENSE) — MIT.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -55,7 +55,7 @@ flowchart LR
         IMG["GHCR: tw-dl-runner image"]
     end
 
-    U -- "/dl, /dl-spoiler, /threaddl" --> BOT
+    U -- "/dl, /dl-spoiler, /threaddl (in dev)" --> BOT
     BOT --> LIBS
     LIBS -- "ky.post(DISPATCH_URL)" --> DISPATCH
     DISPATCH --> ACT

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,106 @@
+# Architecture
+
+`tw-dl-bot` is split into two cooperating processes:
+
+1. **Bot service** — a long-running Deno process that talks to Discord (gateway + REST) and exposes an HTTP callback endpoint built with [Hono](https://hono.dev/).
+2. **Runner workflow** — a GitHub Actions job (`.github/workflows/run.yml`) that pulls a prebuilt Docker image (`ghcr.io/<owner>/tw-dl-runner:latest`), runs `yt-dlp` against the requested URL, and POSTs progress / success / failure callbacks back to the bot.
+
+The two are decoupled by two HTTP boundaries:
+
+- Bot → GitHub: `POST` to a `repository_dispatch` URL that triggers the runner workflow.
+- GitHub Actions → Bot: `POST` to the bot's `/api/callback` endpoint with status updates and the resulting media file.
+
+## End-to-end flow
+
+```mermaid
+sequenceDiagram
+    participant U as User (Discord)
+    participant D as Discord API
+    participant B as tw-dl-bot (Deno)
+    participant GH as GitHub Actions
+    participant R as Runner Container (yt-dlp)
+
+    U->>D: /dl url:<tweet URL>
+    D->>B: interactionCreate
+    B-->>D: Deferred response + "Queuing..." follow-up
+    B->>GH: repository_dispatch (event_type: "download")
+    GH->>R: start job (run.yml)
+    R-->>B: POST /api/callback (status: progress, "Starting...")
+    B->>D: editFollowupMessage (progress)
+    R-->>B: POST /api/callback (status: progress, "Setup...")
+    B->>D: editFollowupMessage (progress)
+    R->>R: yt-dlp download + ffmpeg convert
+    R-->>B: POST /api/callback (status: success, multipart file)
+    B->>D: editFollowupMessage (success embed + attachment)
+```
+
+## Component map
+
+```mermaid
+flowchart LR
+    subgraph Discord
+        U[User]
+    end
+
+    subgraph Bot["tw-dl-bot (Deno process)"]
+        BOT["src/bot/<br/>discordeno gateway + commands"]
+        ROUTER["src/router/<br/>Hono HTTP server"]
+        LIBS["src/libs/<br/>webhook, messages, secrets"]
+        UTILS["src/utils/<br/>byte/time/blob helpers"]
+    end
+
+    subgraph GitHub["GitHub"]
+        DISPATCH["repository_dispatch API"]
+        ACT["Actions: run.yml"]
+        IMG["GHCR: tw-dl-runner image"]
+    end
+
+    U -- "/dl, /dl-spoiler, /threaddl" --> BOT
+    BOT --> LIBS
+    LIBS -- "ky.post(DISPATCH_URL)" --> DISPATCH
+    DISPATCH --> ACT
+    ACT -- "docker pull" --> IMG
+    ACT -- "POST /api/callback" --> ROUTER
+    ROUTER --> LIBS
+    ROUTER --> UTILS
+    LIBS -- "discordeno REST" --> U
+```
+
+## Module layout
+
+| Path | Responsibility |
+| --- | --- |
+| `src/main.ts` | Boots the bot (`startBot`) and the Hono server (`serve`); mounts the API router at `/api`. |
+| `src/bot/bot.ts` | Creates the discordeno bot, registers global slash commands, dispatches `interactionCreate`. |
+| `src/bot/commands.ts` | Slash command definitions for `dl`, `dl-spoiler`, `threaddl`. |
+| `src/bot/interactionCreate.ts` | Validates URL arguments, posts an initial "Queuing..." follow-up, fires the GitHub `repository_dispatch`. |
+| `src/router/index.ts` | Mounts `ping` and `callback` routes under `/api`. |
+| `src/router/ping.ts` | Health check at `GET /api/ping` returning `OK!`. |
+| `src/router/callback.ts` | `POST /api/callback` — pattern-matches the body and dispatches to success / progress / failure handlers. |
+| `src/router/functions/` | Per-status handlers (`success.dl.single`, `success.dl.multi`, `success.dlSpoiler.*`, `progress`, `failure`). |
+| `src/router/messages/` | Builds the Discord follow-up payloads sent on success / error. |
+| `src/libs/constants.ts` | Centralised constants: HTTP paths, status codes, message colors, command-type / action-type strings. |
+| `src/libs/secrets.ts` | Loads required env vars (`DISCORD_TOKEN`, `DISPATCH_URL`, `GITHUB_TOKEN`); fails fast if any are missing. |
+| `src/libs/webhook.ts` | `ky.post` wrapper that triggers GitHub `repository_dispatch` with the `client_payload`. |
+| `src/libs/messages/` | Builders for progress / success / failure / error embeds. |
+| `src/libs/contents/` | Converts callback bodies into `singleFileContent` / `multiFilesContent` blobs. |
+| `src/utils/` | Pure helpers: `fileToBlob`, `unitChangeForByte`, `millisecondChangeFormat`. |
+| `.github/workflows/build.yml` | Builds and pushes the runner image to GHCR on `push` to `master` and on a daily schedule. |
+| `.github/workflows/run.yml` | The `repository_dispatch` consumer that runs `yt-dlp` and posts callbacks. |
+| `docker/Dockerfile` | The runner image: Ubuntu base + `ffmpeg`, `aria2`, `jq`, `bc`, `gawk`, `curl`, plus a nightly `yt-dlp`. |
+
+## Status lifecycle
+
+The runner pushes one of three statuses to `/api/callback`:
+
+| `status` | Meaning | Bot behaviour |
+| --- | --- | --- |
+| `progress` | Step changed (e.g. setup, downloading, converting). | Edits the existing follow-up message with the new content, as long as it is within `EDIT_FOLLOWUP_MESSAGE_TIME_LIMIT` (15 minutes). |
+| `success` | yt-dlp finished and returned one or more files. | Edits the follow-up to a success embed and attaches the file(s); applies `SPOILER_` prefix when `commandType` is `dl-spoiler`. |
+| `failure` | yt-dlp or one of the runner steps failed. | Edits the follow-up to a failure embed. |
+
+The combination of `status`, `commandType` (`dl` / `dl-spoiler`), and `actionType` (`single` / `multi`) selects the handler in `src/libs/custom.ts` (`Custom.CallbackPattern`).
+
+## Why GitHub Actions?
+
+Running `yt-dlp` inside the bot process would couple egress IP, CPU, and disk to the bot host. Pushing the work to GitHub Actions keeps the bot small and stateless, and lets each download run in a fresh container with the latest `yt-dlp` nightly.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,0 +1,106 @@
+# Slash Command Reference
+
+All commands are registered as **global** application commands by `src/bot/bot.ts`. Definitions live in `src/bot/commands.ts`; the names come from `Constants.Webhook.Json.ClientPayload.CommandType` in `src/libs/constants.ts`.
+
+## `/dl`
+
+Download one or more Tweet videos and post them to the channel.
+
+| Field | Value |
+| --- | --- |
+| Name | `dl` |
+| Description | `Download tweet video` |
+| Type | `1` (chat input) |
+
+### Options
+
+| Option | Type | Required | Description |
+| --- | --- | --- | --- |
+| `url` | `STRING` (3) | yes | Tweet URL. Multiple URLs may be passed by separating them with a single space. |
+
+### Behaviour
+
+1. The bot defers the interaction (`DeferredChannelMessageWithSource`).
+2. The `url` value is split on spaces. Each token is validated with `isUrl`.
+3. If any token is not a URL, the bot replies with an error embed listing the rejected input(s) and stops.
+4. For each URL, the bot:
+   - posts a `🕑Queuing...` follow-up,
+   - fires a `repository_dispatch` event of type `download` with `commandType: "dl"`,
+   - and then receives progress / success / failure callbacks that edit the follow-up.
+5. On success, the file is attached to the success embed.
+
+### Examples
+
+```
+/dl url:https://twitter.com/<user>/status/<id>
+/dl url:https://x.com/<user>/status/<id1> https://x.com/<user>/status/<id2>
+```
+
+## `/dl-spoiler`
+
+Identical to `/dl`, except the resulting file is uploaded with the `SPOILER_` prefix so Discord renders it as a spoiler attachment.
+
+| Field | Value |
+| --- | --- |
+| Name | `dl-spoiler` |
+| Description | `Download tweet video with spoiler` |
+| Type | `1` |
+
+### Options
+
+Same as `/dl`:
+
+| Option | Type | Required | Description |
+| --- | --- | --- | --- |
+| `url` | `STRING` (3) | yes | Tweet URL (space-separated for multiple). |
+
+### Behaviour
+
+The interaction handler is shared with `/dl` (see `src/bot/interactionCreate.ts`); only the `commandType` (`dl-spoiler`) differs in the dispatched payload. On success, the callback handler sets `spoiler: true` when building the message, which causes the file name to be prefixed with `SPOILER_` (`Constants.Message.File.Name.SPOILER_PREFIX`).
+
+### Example
+
+```
+/dl-spoiler url:https://twitter.com/<user>/status/<id>
+```
+
+## `/threaddl` (in development)
+
+> **Status:** declared in `src/bot/commands.ts` but not yet wired into the runtime dispatcher in `src/bot/bot.ts`. Implementation is being developed in a separate stream (see task #2). The notes below describe the intended shape; details may change.
+
+Download multiple Tweets into a Discord **thread** named by the user.
+
+| Field | Value |
+| --- | --- |
+| Name | `threaddl` |
+| Description | `DL multiple Tweets into a thread` |
+| Type | `1` |
+
+### Options (planned)
+
+| Option | Type | Required | Description |
+| --- | --- | --- | --- |
+| `name` | `STRING` (3) | yes | Thread name to create. |
+| `url` | `STRING` (3) | yes | Tweet URL. Space-separated for multiple. |
+
+### Intended behaviour
+
+The bot will create a thread with the given `name` and post each download result inside that thread, in parallel, using the same dispatch / callback pipeline as `/dl`. The `commandType` carried in the dispatch payload will be `threaddl`, and the runner workflow will fan out across the supplied URLs.
+
+## Command type tokens
+
+The string values used in dispatch payloads and callbacks are defined once and reused across the bot, the router, and the workflow:
+
+| Constant | Value |
+| --- | --- |
+| `Constants.Webhook.Json.ClientPayload.CommandType.DOWNLOAD` | `dl` |
+| `Constants.Webhook.Json.ClientPayload.CommandType.DOWNLOAD_SPOILER` | `dl-spoiler` |
+| `Constants.Webhook.Json.ClientPayload.CommandType.THREAD_DOWNLOAD` | `threaddl` |
+
+## Common errors
+
+| Surface | Cause |
+| --- | --- |
+| `❌Failure!` embed | The runner workflow finished with the `failure` status (download timeout, link expired, no video file found, oversized file, etc.). The runner posts which step failed via the embed description. |
+| `⚠️Error!` embed (immediate) | One or more of the supplied tokens did not parse as a URL. |
+| Nothing happens | The bot process is offline, or the `repository_dispatch` POST failed (check `DISPATCH_URL` and `GITHUB_TOKEN`). |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,6 +1,6 @@
 # Slash Command Reference
 
-All commands are registered as **global** application commands by `src/bot/bot.ts`. Definitions live in `src/bot/commands.ts`; the names come from `Constants.Webhook.Json.ClientPayload.CommandType` in `src/libs/constants.ts`.
+All command **definitions** live in `src/bot/commands.ts`; their names come from `Constants.Webhook.Json.ClientPayload.CommandType` in `src/libs/constants.ts`. At runtime, `src/bot/bot.ts` only registers `dl` and `dl-spoiler` as **global** application commands and only dispatches those two in `interactionCreate`. The `threaddl` definition is present but not yet wired up (see [`/threaddl` (in development)](#threaddl-in-development) below).
 
 ## `/dl`
 
@@ -14,15 +14,15 @@ Download one or more Tweet videos and post them to the channel.
 
 ### Options
 
-| Option | Type | Required | Description |
-| --- | --- | --- | --- |
-| `url` | `STRING` (3) | yes | Tweet URL. Multiple URLs may be passed by separating them with a single space. |
+| Option | Type | Required | Discord description (literal) | Purpose |
+| --- | --- | --- | --- | --- |
+| `url` | `STRING` (3) | yes | `Tweet URL` | Tweet URL. Multiple URLs may be passed by separating them with a single space (the bot splits on space and validates each token client-side). |
 
 ### Behaviour
 
 1. The bot defers the interaction (`DeferredChannelMessageWithSource`).
 2. The `url` value is split on spaces. Each token is validated with `isUrl`.
-3. If any token is not a URL, the bot replies with an error embed listing the rejected input(s) and stops.
+3. If any token fails URL validation, the bot replies with a single error embed whose description lists **all** supplied tokens (newline-separated), not only the invalid ones, and then stops.
 4. For each URL, the bot:
    - posts a `🕑Queuing...` follow-up,
    - fires a `repository_dispatch` event of type `download` with `commandType: "dl"`,
@@ -31,7 +31,7 @@ Download one or more Tweet videos and post them to the channel.
 
 ### Examples
 
-```
+```text
 /dl url:https://twitter.com/<user>/status/<id>
 /dl url:https://x.com/<user>/status/<id1> https://x.com/<user>/status/<id2>
 ```
@@ -50,9 +50,9 @@ Identical to `/dl`, except the resulting file is uploaded with the `SPOILER_` pr
 
 Same as `/dl`:
 
-| Option | Type | Required | Description |
-| --- | --- | --- | --- |
-| `url` | `STRING` (3) | yes | Tweet URL (space-separated for multiple). |
+| Option | Type | Required | Discord description (literal) | Purpose |
+| --- | --- | --- | --- | --- |
+| `url` | `STRING` (3) | yes | `Tweet URL` | Tweet URL (space-separated for multiple). |
 
 ### Behaviour
 
@@ -60,7 +60,7 @@ The interaction handler is shared with `/dl` (see `src/bot/interactionCreate.ts`
 
 ### Example
 
-```
+```text
 /dl-spoiler url:https://twitter.com/<user>/status/<id>
 ```
 
@@ -78,10 +78,10 @@ Download multiple Tweets into a Discord **thread** named by the user.
 
 ### Options (planned)
 
-| Option | Type | Required | Description |
-| --- | --- | --- | --- |
-| `name` | `STRING` (3) | yes | Thread name to create. |
-| `url` | `STRING` (3) | yes | Tweet URL. Space-separated for multiple. |
+| Option | Type | Required | Discord description (literal) | Purpose |
+| --- | --- | --- | --- | --- |
+| `name` | `STRING` (3) | yes | `Thread Name` | Thread name to create. |
+| `url` | `STRING` (3) | yes | `Tweet URL` | Tweet URL. Space-separated for multiple. |
 
 ### Intended behaviour
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,104 @@
+# Deployment
+
+The deployable surface of this project has two pieces:
+
+1. The **bot service** (`src/main.ts`) — a long-running Deno process that must reach Discord and accept inbound HTTP from GitHub Actions.
+2. The **runner image** (`docker/Dockerfile`) — a Docker image consumed by `.github/workflows/run.yml`. It is rebuilt automatically by `.github/workflows/build.yml`.
+
+## 1. Runner image
+
+The runner is an Ubuntu-based image with the tools `yt-dlp` needs at runtime: `ffmpeg`, `aria2`, `jq`, `bc`, `gawk`, `curl`. `yt-dlp` itself is downloaded as a stable binary then immediately switched to the latest nightly build inside the same `RUN` layer.
+
+### Automatic build (default)
+
+`.github/workflows/build.yml` builds and pushes `ghcr.io/<owner>/tw-dl-runner:latest`:
+
+- on every `push` to `master`, and
+- on a daily schedule (`0 15 * * *` UTC).
+
+It logs in to GHCR with the workflow's built-in `GITHUB_TOKEN` (which is granted `packages: write` in the job permissions block) and runs `docker build -f docker/Dockerfile -t <image> ./docker` followed by `docker push`.
+
+### Manual build (for testing)
+
+```bash
+IMAGE=ghcr.io/<owner>/tw-dl-runner:latest
+docker build -f docker/Dockerfile -t "${IMAGE}" ./docker
+echo "${CR_PAT}" | docker login ghcr.io -u "<your-username>" --password-stdin
+docker push "${IMAGE}"
+```
+
+The runner workflow always pulls `:latest`, so a successful push is enough to roll out a new runner — no application redeploy is required.
+
+## 2. Bot service
+
+The bot can be deployed in any environment that can:
+
+- reach `discord.com` (gateway + REST),
+- reach `api.github.com` to POST `repository_dispatch` events,
+- accept inbound HTTPS on `/api/callback` from `github.com`'s Actions runners.
+
+### Build
+
+```bash
+deno task build
+```
+
+This produces a self-contained executable at `./build/main` via `deno compile -A --import-map import_map.json -o build/main src/main.ts`. The compile uses `-A` (all permissions) — review your hosting environment's expectations before running.
+
+### Run
+
+```bash
+DISCORD_TOKEN=...
+DISPATCH_URL=https://api.github.com/repos/<owner>/<repo>/dispatches
+GITHUB_TOKEN=...
+deno task start   # runs ./build/main
+```
+
+Or, without compiling:
+
+```bash
+deno task run
+```
+
+The Hono server listens on the port chosen by `Deno.serve` (default `8000`).
+
+### Required environment variables
+
+See [development.md](./development.md#environment-variables) for the same table; the variables are identical between local development and production. Treat the PAT (`GITHUB_TOKEN`) as a long-lived credential — rotate it on a schedule.
+
+### Reverse proxy / TLS
+
+Discord and GitHub both require HTTPS for webhook-style endpoints. Terminate TLS at a reverse proxy (Caddy, nginx, Cloudflare Tunnel, fly.io edge, etc.) and forward to the bot's HTTP port. The callback path must be reachable as `https://<your-host>/api/callback`.
+
+### GitHub Actions secret
+
+Set `ENDPOINT_URL` in the **target repository's** Actions secrets to the public URL of the bot's callback endpoint, e.g.:
+
+```
+ENDPOINT_URL = https://bot.example.com/api/callback
+```
+
+The runner workflow uses this when posting progress / success / failure updates.
+
+## Health check
+
+```
+GET /api/ping  -> 200 OK with body "OK!"
+```
+
+Use this for uptime checks or load-balancer health probes.
+
+## Rolling out changes
+
+| Change | What to redeploy |
+| --- | --- |
+| TypeScript source under `src/` | Bot service. |
+| `docker/Dockerfile` | Runner image (push to `master` triggers `build.yml`). No bot redeploy needed. |
+| `.github/workflows/run.yml` | Nothing — the workflow is read from the default branch on each dispatch. |
+| Slash command additions / removals | Bot service. `createGlobalApplicationCommand` is called at startup. Global commands can take up to an hour to propagate. |
+
+## Operational notes
+
+- The bot updates its presence with current RAM usage every 10 seconds (`UPDATE_BOT_STATUS_INTERVAL`).
+- Discord follow-up messages can only be edited for 15 minutes after the original interaction (`EDIT_FOLLOWUP_MESSAGE_TIME_LIMIT`); long-running downloads will stop receiving progress edits past that window even though the workflow keeps running.
+- The runner image is intentionally rebuilt nightly so that `yt-dlp` and its dependencies stay current with site changes.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -60,7 +60,7 @@ Or, without compiling:
 deno task run
 ```
 
-The Hono server listens on the port chosen by `Deno.serve` (default `8000`).
+The Hono server is served via the `serve` helper from `std/http/server` (`https://deno.land/std@0.193.0/http/server.ts`), which listens on `0.0.0.0:8000` by default.
 
 ### Required environment variables
 
@@ -74,7 +74,7 @@ Discord and GitHub both require HTTPS for webhook-style endpoints. Terminate TLS
 
 Set `ENDPOINT_URL` in the **target repository's** Actions secrets to the public URL of the bot's callback endpoint, e.g.:
 
-```
+```text
 ENDPOINT_URL = https://bot.example.com/api/callback
 ```
 
@@ -82,7 +82,7 @@ The runner workflow uses this when posting progress / success / failure updates.
 
 ## Health check
 
-```
+```http
 GET /api/ping  -> 200 OK with body "OK!"
 ```
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -10,7 +10,7 @@
 
 ## Repository layout (top level)
 
-```
+```text
 .
 ├── deno.json               # tasks (dev, lint, build, run, start, cache)
 ├── scripts.json            # denon config used by `deno task dev`
@@ -73,14 +73,14 @@ deno task start
 
 ### What runs at startup
 
-`src/main.ts`:
+`src/main.ts` imports `bot` from `src/bot/bot.ts`. As a side effect of that import, `bot.ts` runs two top-level `await bot.helpers.createGlobalApplicationCommand(...)` calls that register the `dl` and `dl-spoiler` global slash commands. Then `main.ts`:
 
 1. Loads `Secrets` (fails fast on missing env vars).
-2. Calls `startBot(bot)` to open the Discord gateway connection and registers the `dl` and `dl-spoiler` global slash commands.
-3. Mounts the Hono app at `/api` and serves it via `std/http/server`.
+2. Calls `startBot(bot)` to open the Discord gateway connection.
+3. Mounts the Hono app at `/api` and serves it via the `serve` helper from `std/http/server`.
 4. Starts a periodic RAM-usage update on the bot status (`Bot.updateRAMUsage2BotStatus`, every 10 seconds).
 
-The HTTP server listens on the default port chosen by `serve` (`Deno.serve` defaults to `0.0.0.0:8000` unless overridden via env). When developing locally, expose this port to the public internet (e.g. with [ngrok](https://ngrok.com/) or [Cloudflare Tunnel](https://www.cloudflare.com/products/tunnel/)) and set `ENDPOINT_URL` in your GitHub Actions secrets to the public URL of `/api/callback`.
+The HTTP server listens on `0.0.0.0:8000` by default (the `serve` from `https://deno.land/std@0.193.0/http/server.ts` is the one actually used — not `Deno.serve`). When developing locally, expose this port to the public internet (e.g. with [ngrok](https://ngrok.com/) or [Cloudflare Tunnel](https://www.cloudflare.com/products/tunnel/)) and set `ENDPOINT_URL` in your GitHub Actions secrets to the public URL of `/api/callback`.
 
 ## Troubleshooting
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,91 @@
+# Development
+
+## Prerequisites
+
+- [Deno](https://deno.land/) — the bot is written in TypeScript and runs on Deno. The exact version is not pinned via `deno.json`; a recent stable release is fine.
+- [denon](https://deno.land/x/denon) — used by `deno task dev` for file-watching reloads (`scripts.json`).
+- A Discord application with a bot token.
+- A GitHub repository that hosts the runner workflow and accepts `repository_dispatch` events.
+- A GitHub Personal Access Token (PAT) with permission to dispatch repository events (see "GitHub token" below).
+
+## Repository layout (top level)
+
+```
+.
+├── deno.json               # tasks (dev, lint, build, run, start, cache)
+├── scripts.json            # denon config used by `deno task dev`
+├── import_map.json         # import map for std + third-party deps
+├── src/                    # bot + router + libs + utils + main entry
+├── tools/textlint.ts       # custom textlint runner used by `deno task lint`
+├── docker/Dockerfile       # runner image (Ubuntu + ffmpeg + yt-dlp)
+└── .github/workflows/      # build.yml (image) and run.yml (download job)
+```
+
+## Environment variables
+
+The bot fails fast on startup if any of the variables in `Constants.SECRETS` is missing (`src/libs/secrets.ts`).
+
+| Variable | Required | Purpose |
+| --- | --- | --- |
+| `DISCORD_TOKEN` | yes | Discord bot token. Used by discordeno to authenticate the gateway and REST calls. |
+| `DISPATCH_URL` | yes | Full URL of the GitHub `repository_dispatch` endpoint, e.g. `https://api.github.com/repos/<owner>/<repo>/dispatches`. |
+| `GITHUB_TOKEN` | yes | PAT used as `Authorization: token <...>` when posting to `DISPATCH_URL`. |
+
+A `.env` file at the repository root is read by the runtime (the project uses `@redpeacock78/unienv` to read env vars uniformly across environments). Do **not** commit real secrets — keep `.env` ignored locally and use placeholder values when sharing.
+
+### GitHub token scopes
+
+The PAT used as `GITHUB_TOKEN` must be allowed to trigger `repository_dispatch` on the target repository:
+
+- **Classic PAT:** the `repo` scope (or at minimum `public_repo` for a public repo) plus `workflow` is sufficient.
+- **Fine-grained PAT:** grant access to the target repository with **Contents: Read and write** and **Metadata: Read-only**; the dispatch endpoint is gated by repository write access.
+
+The runner workflow itself uses the built-in `GITHUB_TOKEN` (with `packages: write`) to push the runner image to GHCR — that is configured in `build.yml` and is separate from the PAT above.
+
+## Common tasks
+
+All tasks below are defined in `deno.json` (and mirrored in `scripts.json` for denon).
+
+```bash
+# Watch-and-reload development server
+deno task dev
+
+# Run the bot once (no reload)
+deno task run
+
+# Cache imports declared in import_map.json
+deno task cache
+
+# Lint TypeScript and run textlint over root files
+deno task lint
+
+# Compile a self-contained binary into ./build/main
+deno task build
+
+# Run the compiled binary
+deno task start
+```
+
+`deno task lint` runs:
+
+1. `deno lint` over all TypeScript sources, and
+2. `deno run --allow-env --allow-read --allow-sys tools/textlint.ts *` — a custom runner that loads `.textlintrc` and lints the files passed as arguments. The shell glob `*` expands to top-level files only.
+
+### What runs at startup
+
+`src/main.ts`:
+
+1. Loads `Secrets` (fails fast on missing env vars).
+2. Calls `startBot(bot)` to open the Discord gateway connection and registers the `dl` and `dl-spoiler` global slash commands.
+3. Mounts the Hono app at `/api` and serves it via `std/http/server`.
+4. Starts a periodic RAM-usage update on the bot status (`Bot.updateRAMUsage2BotStatus`, every 10 seconds).
+
+The HTTP server listens on the default port chosen by `serve` (`Deno.serve` defaults to `0.0.0.0:8000` unless overridden via env). When developing locally, expose this port to the public internet (e.g. with [ngrok](https://ngrok.com/) or [Cloudflare Tunnel](https://www.cloudflare.com/products/tunnel/)) and set `ENDPOINT_URL` in your GitHub Actions secrets to the public URL of `/api/callback`.
+
+## Troubleshooting
+
+- **`Not all secrets are set.`** — One of `DISCORD_TOKEN`, `DISPATCH_URL`, `GITHUB_TOKEN` is missing or empty.
+- **No interactions received** — Ensure the bot has the `applications.commands` and `bot` scopes when invited to the guild.
+- **`repository_dispatch` returns 404** — The `DISPATCH_URL` is wrong, the PAT lacks scope, or the workflow file does not declare `on.repository_dispatch.types: [download]`.
+- **Callbacks never reach the bot** — `ENDPOINT_URL` (a GH Actions secret) does not point at a publicly reachable `/api/callback`. Check tunnel logs.
+- **Follow-up edits stop after 15 minutes** — Discord rate-limits follow-up message edits past the original interaction's lifetime; the bot enforces this via `Constants.EDIT_FOLLOWUP_MESSAGE_TIME_LIMIT`.

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -41,7 +41,7 @@ The runner posts to the URL in the `ENDPOINT_URL` Actions secret (which should r
 | Field | Type | Notes |
 | --- | --- | --- |
 | `status` | `"success" \| "failure" \| "progress" \| null` | Drives which handler runs. |
-| `number` | `string` | `${{ github.run_number }}`, displayed in success / failure embeds. |
+| `number` | `string` (per `CallbackTypes.bodyDataObject`) | `${{ github.run_number }}`, displayed in success / failure embeds. The producer is inconsistent: `run.yml` injects the value unquoted into JSON callbacks (so it arrives as a JSON number) and as a plain `multipart/form-data` field on success (string). The router does not coerce it, so `body.number` may be either at runtime even though the type declares `string`. |
 | `commandType` | `"dl" \| "dl-spoiler"` (optional) | Required for `success`; selects single vs. spoiler handler. |
 | `actionType` | `"single" \| "multi"` (optional) | Required for `success`; selects single-file vs. multi-file handler. |
 | `startTime` | `string` | Echo of the bot-supplied `startTime`; used to compute elapsed time. |
@@ -68,19 +68,21 @@ The router uses `Custom.CallbackPattern` (`src/libs/custom.ts`) to pick a handle
 | `["success", "dl", "multi"]` | `success.dl.multi` — sends multiple attached files. |
 | `["success", "dl-spoiler", "single"]` | `success.dlSpoiler.single` — same as above, with `SPOILER_` prefix. |
 | `["success", "dl-spoiler", "multi"]` | `success.dlSpoiler.multi` — multi-file spoiler. |
-| `["progress", null, null]` | `progress` — edits the existing follow-up message (within the 15-minute edit window). |
-| `["failure", null, null]` | `failure` — replies with a failure embed. |
-| `[null, null, null]` | Returns `400 Bad Request`. |
+| `["progress", <nullish>, <nullish>]` | `progress` — edits the existing follow-up message (within the 15-minute edit window). The `commandType` and `actionType` fields are omitted by `run.yml` for progress callbacks, so the matcher uses `P.nullish`. |
+| `["failure", <nullish>, <nullish>]` | `failure` — replies with a failure embed. Same `P.nullish` matching as `progress`. |
+| `[<nullish>, <nullish>, <nullish>]` | `InvalidPost` — body parsed, but `status`, `commandType`, and `actionType` are all missing. Returns `400 Bad Request`. |
 
 Anything else returns `500 Internal Server Error`.
 
 ### Response codes
 
-| Outcome | Code |
+These are decided by `src/router/callback.ts` after the body is parsed and the `[status, commandType, actionType]` triplet is matched against `Custom.CallbackPattern`:
+
+| Code | When |
 | --- | --- |
-| Successfully edited / posted to Discord | `204 No Content` |
-| Body could not be parsed or required fields are missing | `400 Bad Request` |
-| Discord API call failed (network or 4xx/5xx) | `500 Internal Server Error` |
+| `204 No Content` | A handler ran and the Discord API call succeeded. |
+| `400 Bad Request` | Body parsed (JSON or multipart), but `status`, `commandType`, and `actionType` are all missing — the `InvalidPost` pattern. |
+| `500 Internal Server Error` | Falls through to `.otherwise` — used for body-parse failures and for any other `[status, commandType, actionType]` combination not enumerated above. Discord API errors inside a handler are also reported as `500` by the per-handler `.catch`. |
 
 ## Secrets
 
@@ -98,7 +100,7 @@ Anything else returns `500 Internal Server Error`.
 
 1. **Masking Secrets** — masks `commandType`, `link`, `channel`, `message`, `token` with `::add-mask::` so they never appear in logs.
 2. **Start Steps / Setup** — posts `progress` callbacks with `⏳Starting...`, `🛠Setup...`, etc., while it ensures `yt-dlp` is on the latest nightly.
-3. **Confirmation of link survival** — issues a `HEAD` to the supplied URL to bail out early on dead links.
+3. **Confirmation of link survival** — issues a `GET` (`curl -siL`, headers + follow redirects, body discarded) to the supplied URL to bail out early on dead links.
 4. **Start Download** — runs `yt-dlp` with the streaming progress hooks defined in the bash/awk scripts that earlier steps wrote out.
 5. **Check and Convert Files** — re-encodes via `ffmpeg` when needed.
 6. **Upload files** — sends a `success` callback to `/api/callback` with the resulting file(s) attached as multipart parts.

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -1,0 +1,112 @@
+# GitHub Actions Integration
+
+The bot offloads all `yt-dlp` work to GitHub Actions. Two workflows are involved:
+
+| Workflow | File | Purpose |
+| --- | --- | --- |
+| Build runner image | `.github/workflows/build.yml` | Builds and pushes `ghcr.io/<owner>/tw-dl-runner:latest` on `push` to `master` and on a daily schedule. |
+| Run download | `.github/workflows/run.yml` | Triggered by a `repository_dispatch` event of type `download`. Runs the runner container and posts progress / success / failure callbacks. |
+
+## Trigger: `repository_dispatch`
+
+The bot calls `POST {DISPATCH_URL}` (see `src/libs/webhook.ts`) with the standard GitHub repository_dispatch shape:
+
+```http
+POST {DISPATCH_URL}
+Authorization: token {GITHUB_TOKEN}
+Accept: application/vnd.github.everest-preview+json
+Content-Type: application/json
+
+{
+  "event_type": "download",
+  "client_payload": {
+    "commandType": "dl" | "dl-spoiler" | "threaddl",
+    "link": "https://twitter.com/.../status/...",
+    "channel": "<discord channel id, stringified>",
+    "message": "<discord follow-up message id, stringified>",
+    "token": "<discord interaction token>",
+    "startTime": "<unix-ms timestamp, stringified>"
+  }
+}
+```
+
+`DISPATCH_URL` is conventionally `https://api.github.com/repos/<owner>/<repo>/dispatches`.
+
+`run.yml` consumes these fields via `${{ github.event.client_payload.* }}`, masks the user-controlled values with `::add-mask::` to keep them out of the public log, and passes them on to each callback.
+
+## Callback: `POST /api/callback`
+
+The runner posts to the URL in the `ENDPOINT_URL` Actions secret (which should resolve to the bot's public `/api/callback`). The shape is defined by `CallbackTypes.bodyDataObject` in `src/router/types/callbackTypes.ts`:
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `status` | `"success" \| "failure" \| "progress" \| null` | Drives which handler runs. |
+| `number` | `string` | `${{ github.run_number }}`, displayed in success / failure embeds. |
+| `commandType` | `"dl" \| "dl-spoiler"` (optional) | Required for `success`; selects single vs. spoiler handler. |
+| `actionType` | `"single" \| "multi"` (optional) | Required for `success`; selects single-file vs. multi-file handler. |
+| `startTime` | `string` | Echo of the bot-supplied `startTime`; used to compute elapsed time. |
+| `channel` | `string` | Discord channel ID (echoed). |
+| `message` | `string` | Discord follow-up message ID (echoed). |
+| `token` | `string` | Discord interaction token (echoed). |
+| `link` | `string` | The original Tweet URL (echoed). |
+| `convert` | `"true" \| "false"` (optional) | Whether the runner had to re-encode the file. |
+| `oversize` | `"true" \| "false"` (optional) | `"true"` when the resulting file exceeded Discord's upload limit; the bot then surfaces the file via a different path. |
+| `name1`..`name4`, `file1`..`file4` | `string` / `File` (optional) | File names and `multipart/form-data` parts when uploading 1–4 result files. |
+| `size` | `string` (optional) | Total upload size in bytes (used in success embeds). |
+| `type` | `string` | Free-form context tag from the runner. |
+| `content` | `string` (optional) | Step description shown to the user during `progress` callbacks (e.g. `🛠Setup...`). |
+
+Progress callbacks ship as `application/json`. Success callbacks that include attachments are sent as `multipart/form-data` (the router parses both).
+
+### Status routing
+
+The router uses `Custom.CallbackPattern` (`src/libs/custom.ts`) to pick a handler based on `[status, commandType, actionType]`:
+
+| Pattern | Handler |
+| --- | --- |
+| `["success", "dl", "single"]` | `success.dl.single` — sends one attached file with a success embed. |
+| `["success", "dl", "multi"]` | `success.dl.multi` — sends multiple attached files. |
+| `["success", "dl-spoiler", "single"]` | `success.dlSpoiler.single` — same as above, with `SPOILER_` prefix. |
+| `["success", "dl-spoiler", "multi"]` | `success.dlSpoiler.multi` — multi-file spoiler. |
+| `["progress", null, null]` | `progress` — edits the existing follow-up message (within the 15-minute edit window). |
+| `["failure", null, null]` | `failure` — replies with a failure embed. |
+| `[null, null, null]` | Returns `400 Bad Request`. |
+
+Anything else returns `500 Internal Server Error`.
+
+### Response codes
+
+| Outcome | Code |
+| --- | --- |
+| Successfully edited / posted to Discord | `204 No Content` |
+| Body could not be parsed or required fields are missing | `400 Bad Request` |
+| Discord API call failed (network or 4xx/5xx) | `500 Internal Server Error` |
+
+## Secrets
+
+| Where | Name | Purpose |
+| --- | --- | --- |
+| Bot environment | `DISCORD_TOKEN` | Discord bot token. |
+| Bot environment | `DISPATCH_URL` | The `repository_dispatch` URL of the runner repo. |
+| Bot environment | `GITHUB_TOKEN` | PAT used by the bot to call `DISPATCH_URL`. See [development.md](./development.md#github-token-scopes). |
+| GitHub Actions (runner repo) | `ENDPOINT_URL` | Public URL of the bot's `/api/callback`. Used by `run.yml` to send progress / success / failure callbacks. |
+| GitHub Actions (built-in) | `GITHUB_TOKEN` | Used by `build.yml` to push the runner image to GHCR (`packages: write`). Provided by Actions; nothing to configure manually. |
+
+## Runner workflow steps (high level)
+
+`.github/workflows/run.yml` runs entirely inside the prebuilt runner container. The major steps:
+
+1. **Masking Secrets** — masks `commandType`, `link`, `channel`, `message`, `token` with `::add-mask::` so they never appear in logs.
+2. **Start Steps / Setup** — posts `progress` callbacks with `⏳Starting...`, `🛠Setup...`, etc., while it ensures `yt-dlp` is on the latest nightly.
+3. **Confirmation of link survival** — issues a `HEAD` to the supplied URL to bail out early on dead links.
+4. **Start Download** — runs `yt-dlp` with the streaming progress hooks defined in the bash/awk scripts that earlier steps wrote out.
+5. **Check and Convert Files** — re-encodes via `ffmpeg` when needed.
+6. **Upload files** — sends a `success` callback to `/api/callback` with the resulting file(s) attached as multipart parts.
+7. **Failure paths** — explicit `failure` callbacks for "Link has expired", "Video file not found", "Uploaded file size exceeded", "Download timed out".
+8. **Cleanup temp files** — always runs.
+
+If you change the schema, update both ends:
+
+- `src/libs/webhook.ts` (request shape going to GitHub),
+- `src/router/types/callbackTypes.ts` (response shape coming back),
+- `.github/workflows/run.yml` (the producer of the response).


### PR DESCRIPTION
## Summary

Add a developer-facing `docs/` directory and refresh the root `README.md` so contributors can navigate the bot, the GitHub Actions runner workflow, and the deployment story without having to read source.

## Added documentation

| File | Contents |
| --- | --- |
| `docs/README.md` | Index for the docs directory. |
| `docs/architecture.md` | System overview, end-to-end Mermaid sequence diagram (Discord ↔ Bot ↔ GH Actions ↔ yt-dlp), component map, module-by-module table, status lifecycle. |
| `docs/commands.md` | Reference for `/dl`, `/dl-spoiler`, and `/threaddl` (the latter flagged as in development). Options, behaviour, examples, and the shared command-type tokens. |
| `docs/development.md` | Prerequisites, env vars (`DISCORD_TOKEN`, `DISPATCH_URL`, `GITHUB_TOKEN`), required PAT scopes, common `deno task` commands, troubleshooting. |
| `docs/deployment.md` | Runner image build/publish (`build.yml` + manual), bot service deployment, required GH Actions `ENDPOINT_URL` secret, rollout matrix. |
| `docs/github-actions.md` | `repository_dispatch` payload schema, full `/api/callback` body schema (from `CallbackTypes.bodyDataObject`), status routing table (`Custom.CallbackPattern`), HTTP response codes, secrets matrix, runner workflow step summary. |

## README updates

- Slash command list now includes `/dl-spoiler` and `/threaddl` (with an *(in development)* note for `/threaddl`).
- Added a new **Documentation** section linking to each file under `docs/`.
- Setup, badges, tech stack, and license sections are unchanged.

## Review notes

- Docs are written in English to match the existing English README and to avoid `preset-ja-technical-writing` textlint noise.
- `/threaddl` content intentionally stays high-level — implementation is being completed in a separate stream (task #2). Only the planned options and intended behaviour are described.
- Facts were sourced from the codebase: `src/bot/commands.ts`, `src/bot/bot.ts`, `src/bot/interactionCreate.ts`, `src/router/callback.ts`, `src/router/types/callbackTypes.ts`, `src/libs/constants.ts`, `src/libs/custom.ts`, `src/libs/secrets.ts`, `src/libs/webhook.ts`, `.github/workflows/{build,run}.yml`, and `docker/Dockerfile`. No facts about unimplemented behaviour are asserted as current.
- Mermaid renders natively on GitHub, so no extra tooling is needed to view the diagrams.
- `deno task lint` reports 8 preexisting errors in `tools/textlint.ts` (all `no-import-prefix` / `no-unversioned-import` on the `npm:` specifiers). These are present on `master` and not introduced by this PR.

## Out of scope

- No code changes under `src/`.
- No changes to workflows, Dockerfile, or build tooling.
- `/threaddl` runtime wiring (covered by a parallel stream).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README with explicit slash command definitions and references to comprehensive documentation
  * Added developer and user-facing documentation covering commands, architecture, development, deployment, and GitHub Actions integration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->