### PR TITLE
feat: implement /threaddl command with parallel matrix download

### DIFF
--- a/.github/workflows/run-thread.yml
+++ b/.github/workflows/run-thread.yml
@@ -1,0 +1,962 @@
+name: ThreadDownloaderAction
+on:
+  repository_dispatch:
+    types:
+      - thread-download
+
+jobs:
+  prepare:
+    name: Prepare matrix
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+      count: ${{ steps.set-matrix.outputs.count }}
+    steps:
+      - name: Build matrix from links
+        id: set-matrix
+        shell: bash
+        run: |
+          # Convert client_payload.links into a strategy.matrix `include` array.
+          # Each item carries link + per-URL Discord message ID. The shared
+          # thread channel ID, commandType, token and startTime are read from
+          # the top-level event payload by every matrix shard.
+          matrix="$(jq -c '{include: [.client_payload.links[] | {link: .link, message: .message}]}' "${GITHUB_EVENT_PATH}")"
+          count="$(jq -r '.client_payload.links | length' "${GITHUB_EVENT_PATH}")"
+          echo "matrix=${matrix}" >> "${GITHUB_OUTPUT}"
+          echo "count=${count}" >> "${GITHUB_OUTPUT}"
+          echo "Matrix: ${matrix}"
+          echo "Count: ${count}"
+
+  run-with-container:
+    name: Download (${{ matrix.link }})
+    needs: [prepare]
+    if: ${{ fromJson(needs.prepare.outputs.count) > 0 }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      max-parallel: 16
+      matrix: ${{ fromJson(needs.prepare.outputs.matrix) }}
+    container:
+      image: ghcr.io/${{ github.repository_owner }}/tw-dl-runner:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Masking Secrets
+        shell: bash
+        env:
+          MATRIX_LINK: ${{ matrix.link }}
+          MATRIX_MESSAGE: ${{ matrix.message }}
+        run: |
+          echo -n '::add-mask::' >> secrets.txt && \
+          jq -r .client_payload.commandType < "${GITHUB_EVENT_PATH}" >> secrets.txt && \
+          echo -n '::add-mask::' >> secrets.txt && \
+          jq -r .client_payload.channel < "${GITHUB_EVENT_PATH}" >> secrets.txt && \
+          echo -n '::add-mask::' >> secrets.txt && \
+          jq -r .client_payload.token < "${GITHUB_EVENT_PATH}" >> secrets.txt && \
+          echo -n '::add-mask::' >> secrets.txt && \
+          printf '%s\n' "${MATRIX_LINK}" >> secrets.txt && \
+          echo -n '::add-mask::' >> secrets.txt && \
+          printf '%s\n' "${MATRIX_MESSAGE}" >> secrets.txt && \
+          cat secrets.txt && \
+          rm -rf secrets.txt
+      - name: Start Steps
+        shell: bash
+        run: |
+          {
+            curl -s -X POST \
+              ${{ secrets.ENDPOINT_URL }} \
+              -H "Accept: application/json" \
+              -H "Content-type: application/json" \
+              -m 18000 \
+              --retry 100 \
+              --retry-all-errors \
+              -o /dev/null \
+              -d @- <<EOF
+            {
+              "status": "progress",
+              "number": ${{ github.run_number }},
+              "commandType": ${{ toJSON(github.event.client_payload.commandType) }},
+              "startTime": ${{ toJSON(github.event.client_payload.startTime) }},
+              "channel": ${{ toJSON(github.event.client_payload.channel) }},
+              "message": ${{ toJSON(matrix.message) }},
+              "token": ${{ toJSON(github.event.client_payload.token) }},
+              "link": ${{ toJSON(matrix.link) }},
+              "content": "⏳Starting..."
+            }
+          EOF
+          } || :
+      - name: Setup latest yt-dlp
+        if: ${{ success() }}
+        shell: bash
+        run: |
+          {
+            curl -s -X POST \
+              ${{ secrets.ENDPOINT_URL }} \
+              -H "Accept: application/json" \
+              -H "Content-type: application/json" \
+              -m 18000 \
+              --retry 100 \
+              --retry-all-errors \
+              -o /dev/null \
+              -d @- <<EOF
+            {
+              "status": "progress",
+              "number": ${{ github.run_number }},
+              "commandType": ${{ toJSON(github.event.client_payload.commandType) }},
+              "startTime": ${{ toJSON(github.event.client_payload.startTime) }},
+              "channel": ${{ toJSON(github.event.client_payload.channel) }},
+              "message": ${{ toJSON(matrix.message) }},
+              "token": ${{ toJSON(github.event.client_payload.token) }},
+              "link": ${{ toJSON(matrix.link) }},
+              "content": "🛠Setup..."
+            }
+          EOF
+          } || :
+          type yt-dlp > /dev/null 2>&1 && \
+          {
+            retry=0 && \
+            flag=false && \
+            until "${flag}" || (( "${retry}" == 1000 )); do
+              echo "Retry count: ${retry}" && \
+              echo "Flag status: ${flag}" && \
+              nightly_url="https://github.com/yt-dlp/yt-dlp-nightly-builds/releases/latest/download/yt-dlp" && \
+              version="$(curl -sI -m 18000 --retry 100 --retry-all-errors "${nightly_url}" | grep 'location: ' | awk -F '/' '{print $8}')" && \
+              yt-dlp --update-to "nightly@${version}" && \
+              {
+                flag=true
+              } || \
+              {
+                ((retry++)) || true
+              }
+            done
+          }
+      - name: Setup progress awk script
+        if: ${{ success() }}
+        shell: bash
+        run: |
+          cat <<'EOF' > progress.awk
+          BEGIN{RS="frame="}
+          /Duration: /{
+            match($0, /[0-2][0-3]:[0-5][0-9]:[0-5][0-9]/)
+            TIME=substr($0, RSTART, RLENGTH)
+            split(TIME, array, ":")
+            Dura=array[1]*3600+array[2]*60+array[3]
+            Start=systime()
+            Old=-1
+          }
+          /time=/{
+            match($0, /[0-2][0-3]:[0-5][0-9]:[0-5][0-9]/)
+            Now=substr($0, RSTART, RLENGTH)
+            split(Now, array1, ":")
+            Prog=array1[1]*3600+array1[2]*60+array1[3]
+            Ratio=int(Prog/Dura*100)
+            if ( Ratio != Old ) {
+              if ( Ratio % 1 == 0 ) {
+                Current=systime()
+                px=Current-Start
+                Remain=""
+                if ( Prog != 0 ) {
+                  rx=(Dura*px)/Prog-px
+                  Remain=sprintf(" ETA:%02d:%02d:%02d", int(int(rx)/3600), int(int(rx)/60)%60, int(rx)%60)
+                }
+                printf ("%s/%s(%s%)%s\n", Now, TIME, Ratio, Remain)
+                system("")
+              }
+              Old=Ratio
+            }
+          }
+          EOF
+      - name: Setup progress bash script
+        if: ${{ success() }}
+        shell: bash
+        run: |
+          cat <<'EOF' > /usr/local/bin/conv_progress.sh
+          #!/usr/bin/env bash
+          run_number=${{ github.run_number }}
+          start_time=${{ toJSON(github.event.client_payload.startTime) }}
+          command_type=${{ toJSON(github.event.client_payload.commandType) }}
+          channel=${{ toJSON(github.event.client_payload.channel) }}
+          message=${{ toJSON(matrix.message) }}
+          token=${{ toJSON(github.event.client_payload.token) }}
+          link=${{ toJSON(matrix.link) }}
+
+          interval=1
+          last="$(openssl sha256 -r ${1} | awk '{print $1}')"
+          while true; do
+            sleep "${interval}"
+            current="$(openssl sha256 -r ${1} | awk '{print $1}')"
+            if [[ "${last}" != "${current}" ]]; then
+              retry=0 && \
+              flag=false && \
+              until "${flag}" || (( "${retry}" == 1000 )); do
+                if ((  "${retry}" > 0 )); then
+                  echo "Retry count: ${retry}"
+                  echo "Flag status: ${flag}"
+                fi
+                progress="$(cat ${1} | tail -n1)"
+                if grep -e '^/' <<< "${progress}" > /dev/null; then
+                  progress="00:00:00${progress}"
+                else
+                  :
+                fi
+                echo '{"status": "progress", "number": "'"${run_number}"'", "commandType": "'"${command_type}"'", "startTime": "'"${start_time}"'", "channel": "'"${channel}"'", "message": "'"${message}"'", "token": "'"${token}"'", "link": "'"${link}"'", "content": "'"${4}(${2} / ${3})\n${progress}"'"}' | \
+                curl -s -X POST \
+                  ${{ secrets.ENDPOINT_URL }} \
+                  -H "Accept: application/json" \
+                  -H "Content-type: application/json" \
+                  -m 18000 \
+                  --retry 100 \
+                  --retry-all-errors \
+                  -d @- > /dev/null 2>&1 && \
+                {
+                  flag=true
+                } || \
+                {
+                  ((retry++)) || true
+                }
+              done
+              last="${current}"
+            fi
+          done
+          EOF
+          chmod +x /usr/local/bin/conv_progress.sh
+      - name: Setup wrapper curl bash script
+        if: ${{ success() }}
+        shell: bash
+        run: |
+          cat <<'EOF' > /usr/local/bin/retry_curl.sh
+          #!/usr/bin/env bash
+          declare max="${1}";shift
+          declare delay="${1}";shift
+          [[ "${1:-1}" == "--" ]] && shift || true
+          declare attempt=1
+          declare status
+          while (( attempt <= max )); do
+            status="$(curl -sS -o /dev/null -w '%{http_code}' "${@}")"
+            if [[ "${status}" =~ ^2[0-9][0-9] ]]; then
+              exit 0
+            fi
+            if [[ "${status}" == "499" || "${status}" -ge 500 || "${status}" == "408" || "${status}" == "429" ]]; then
+              echo "Retry ${attempt}/${max} failed with status ${status}. Retrying in ${delay} seconds..."
+              sleep "${delay}"
+              delay=$(( delay * 2 > 60 ? 60 : delay * 2 ))
+              ((attempt++))
+              continue
+            fi
+            echo "Non-retriable error: ${status}" >&2
+            exit 22
+          done
+          echo "Exceeded retries. Last status: ${status}" >&2
+          exit 22
+          EOF
+          chmod +x /usr/local/bin/retry_curl.sh
+      - name: Setup post process bash script
+        if: ${{ success() }}
+        shell: bash
+        run: |
+          cat <<'EOF' > /usr/local/bin/post_process.sh
+          #!/usr/bin/env bash
+          input="${1}"
+          vformat="$(ffprobe -v error -select_streams v:0 -show_entries format=format_name -of default=nk=1:nw=1 "${input}")"
+          vcodec="$(ffprobe -v error -select_streams v:0 -show_entries stream=codec_name -of default=nk=1:nw=1 "${input}")"
+          pix_fmt="$(ffprobe -v error -select_streams v:0 -show_entries stream=pix_fmt -of default=nk=1:nw=1 "${input}")"
+          if [[ "${vformat}" == "mov,mp4,m4a,3gp,3g2,mj2" ]]; then
+            ext="${input##*.}"
+          else
+            ext="mp4"
+          fi
+          tmp="${input%.*}.tmp.${ext}"
+          if [[ ${vformat} != "mov,mp4,m4a,3gp,3g2,mj2" || "${vcodec}" != "h264" || "${pix_fmt}" != "yuv420p" ]]; then
+            ffmpeg -y \
+              -i "${input}" \
+              -threads "$(nproc)" \
+              -preset veryfast \
+              -c:v libx264 \
+              -pix_fmt yuv420p \
+              -c:a copy \
+              -movflags +faststart \
+              "${tmp}" && \
+            rm -f "${input}" && \
+            if [[ "${vformat}" == "mov,mp4,m4a,3gp,3g2,mj2" ]]; then
+              mv "${tmp}" "${input}"
+            else
+              mv "${tmp}" "${input%.*}.${ext}"
+            fi
+          fi
+          EOF
+          chmod +x /usr/local/bin/post_process.sh
+      - name: Confirmation of link survival
+        if: ${{ success() }}
+        id: link_status
+        timeout-minutes: 10
+        shell: bash
+        env:
+          MATRIX_LINK: ${{ matrix.link }}
+        run: |
+          if [[ "${MATRIX_LINK}" =~ ^http.*$ ]]; then
+            {
+              retry_curl.sh 15 2 -- \
+                -X POST \
+                ${{ secrets.ENDPOINT_URL }} \
+                -H "Accept: application/json" \
+                -H "Content-type: application/json" \
+                -m 18000 \
+                --retry 100 \
+                --retry-all-errors \
+                -d @- <<EOF
+              {
+                "status": "progress",
+                "number": ${{ github.run_number }},
+                "commandType": ${{ toJSON(github.event.client_payload.commandType) }},
+                "startTime": ${{ toJSON(github.event.client_payload.startTime) }},
+                "channel": ${{ toJSON(github.event.client_payload.channel) }},
+                "message": ${{ toJSON(matrix.message) }},
+                "token": ${{ toJSON(github.event.client_payload.token) }},
+                "link": ${{ toJSON(matrix.link) }},
+                "content": "🔍Checking link status..."
+              }
+          EOF
+            } || :
+            retry=0 && \
+            flag=false && \
+            status="" && \
+            until "${flag}" || (( "${retry}" == 1000 )); do
+              if (( "${retry}" > 0 )); then
+                {
+                  retry_curl.sh 15 2 -- \
+                    -X POST \
+                    ${{ secrets.ENDPOINT_URL }} \
+                    -H "Accept: application/json" \
+                    -H "Content-type: application/json" \
+                    -m 18000 \
+                    --retry 100 \
+                    --retry-all-errors \
+                    -d @- <<EOF
+                  {
+                    "status": "progress",
+                    "number": ${{ github.run_number }},
+                    "commandType": ${{ toJSON(github.event.client_payload.commandType) }},
+                    "startTime": ${{ toJSON(github.event.client_payload.startTime) }},
+                    "channel": ${{ toJSON(github.event.client_payload.channel) }},
+                    "message": ${{ toJSON(matrix.message) }},
+                    "token": ${{ toJSON(github.event.client_payload.token) }},
+                    "link": ${{ toJSON(matrix.link) }},
+                    "content": "🔍Checking link status...(Retry ${retry} / 1000)"
+                  }
+          EOF
+                } || :
+              fi
+              echo "Retry count: ${retry}"
+              echo "Flag status: ${flag}"
+              status="$(curl -siL -m 18000 --retry 100 --retry-all-errors "${MATRIX_LINK}" -o /dev/null -w '%{http_code}\n';:)"
+              if [[ "${status}" == "200" || "${status}" == "302" || "${status}" == "307" ]]; then
+                flag=true
+              else
+                ((retry++)) || true
+                sleep 1
+              fi
+            done
+            if [[ "${status}" != "200" && "${status}" != "302" && "${status}" != "307" ]]; then
+              status="notfound" && \
+              echo "status=${status}" >> "${GITHUB_OUTPUT}" && \
+              exit 2
+            fi
+          fi
+      - name: Start Download
+        if: ${{ success() }}
+        id: download
+        timeout-minutes: 10
+        shell: bash
+        env:
+          MATRIX_LINK: ${{ matrix.link }}
+        run: |
+          {
+            retry_curl.sh 15 2 -- \
+              -X POST \
+              ${{ secrets.ENDPOINT_URL }} \
+              -H "Accept: application/json" \
+              -H "Content-type: application/json" \
+              -m 18000 \
+              --retry 100 \
+              --retry-all-errors \
+              -d @- <<EOF
+            {
+              "status": "progress",
+              "number": ${{ github.run_number }},
+              "commandType": ${{ toJSON(github.event.client_payload.commandType) }},
+              "startTime": ${{ toJSON(github.event.client_payload.startTime) }},
+              "channel": ${{ toJSON(github.event.client_payload.channel) }},
+              "message": ${{ toJSON(matrix.message) }},
+              "token": ${{ toJSON(github.event.client_payload.token) }},
+              "link": ${{ toJSON(matrix.link) }},
+              "content": "⏬Downloading..."
+            }
+          EOF
+          } || :
+          retry=0 && \
+          flag=false && \
+          not_video=false && \
+          cookie_path="$(pwd)/cookie.txt" && \
+          url="$(printf '%s' "${MATRIX_LINK}" | awk -F '/' '{OFS="/";sub(/^x.com$/,"twitter.com",$3);print $0}')" && \
+          mkdir -p download && \
+          cd download && \
+          IFS=$'\n' && \
+          until "${flag}" || (( "${retry}" == 1000 )); do
+            echo "Retry count: ${retry}"
+            echo "Flag status: ${flag}"
+            if (( "${retry}" > 0 )); then
+              {
+                retry_curl.sh 15 2 -- \
+                  -X POST \
+                  ${{ secrets.ENDPOINT_URL }} \
+                  -H "Accept: application/json" \
+                  -H "Content-type: application/json" \
+                  -m 18000 \
+                  --retry 100 \
+                  --retry-all-errors \
+                  -d @- <<EOF
+                {
+                  "status": "progress",
+                  "number": ${{ github.run_number }},
+                  "commandType": ${{ toJSON(github.event.client_payload.commandType) }},
+                  "startTime": ${{ toJSON(github.event.client_payload.startTime) }},
+                  "channel": ${{ toJSON(github.event.client_payload.channel) }},
+                  "message": ${{ toJSON(matrix.message) }},
+                  "token": ${{ toJSON(github.event.client_payload.token) }},
+                  "link": ${{ toJSON(matrix.link) }},
+                  "content": "⏬Downloading...(Retry ${retry} / 1000)"
+                }
+          EOF
+              } || :
+            fi
+            yt_result="$(mktemp)"
+            options=()
+            if [[ "${url}" =~ "/twitter.com/" ]]; then
+              if [[ ! -f "${cookie_path}" ]]; then
+                echo "${{ secrets.TWITTER_COOKIES }}" >> "${cookie_path}"
+              fi
+              options+=(--cookies "${cookie_path}")
+            fi
+            yt-dlp \
+              -R 1000 \
+              --force-overwrites \
+              --downloader aria2c \
+              --external-downloader-args "--listen-port=5502 --dht-listen-port=5502 -s20 -j20 -x16 -k20M --disable-ipv6=true --continue=true --seed-time=0 --max-tries=0 --retry-wait=10 --summary-interval=0 --file-allocation=none --console-log-level=error --download-result=hide" \
+              --exec "post_process:post_process.sh {}" \
+              -o "%(id).150B_%(autonumber)s.%(ext)s" \
+              "${options[@]}" \
+              "${url}" > "${yt_result}" 2>&1 && \
+              {
+                yt_status="0"
+                true
+              } || \
+              {
+                yt_status="1"
+                true
+              }
+            if [[ "${yt_status}" == "0" ]]; then
+              if [[ "$(cat ${yt_result} | tail -n1 | grep 'No video')" == "" ]]; then
+                for file_name in $(ls -tr); do
+                  if ffprobe -v error -f lavfi movie="${file_name}" > /dev/null 2>&1; then
+                    flag=true
+                  else
+                    :
+                  fi
+                done
+              else
+                :
+              fi
+            elif [[ "${yt_status}" == "1" ]]; then
+              if [[ "$(cat ${yt_result} | tail -n1 | grep 'No video')" != "" ]]; then
+                flag=true
+                not_video=true
+              elif [[ "$(cat ${yt_result} | tail -n1 | grep 'Finished downloading playlist')" != "" ]]; then
+                if (( "$(ls -tr | wc -l )" > 0 )); then
+                  for file_name in $(ls -tr); do
+                    if ffprobe -v error -f lavfi movie="${file_name}" > /dev/null 2>&1; then
+                      flag=true
+                    else
+                      :
+                    fi
+                  done
+                else
+                  not_video=true
+                fi
+              else
+                :
+              fi
+            else
+              not_video=true
+            fi
+            if "${flag}"; then
+              :
+            else
+              ((retry++)) || true
+              sleep 1
+            fi
+          done
+          if "${not_video}"; then
+            status="notvideo" && \
+            echo "status=${status}" >> "${GITHUB_OUTPUT}" && \
+            exit 2
+          fi
+      - name: Check and Convert Files
+        if: ${{ success() }}
+        shell: bash
+        run: |
+          dir=$(pwd) && \
+          cd download && \
+          files_num=$(ls -tr | wc -l) && \
+          if (( 10485760 < $(echo $(ls -trl | awk 'NR>1{print $5}' | tr \\n +)0 | bc) )); then
+            file_list=()
+            IFS=$'\n' && \
+            for file_name in $(ls -tr); do
+              if (( "$(wc -c < "${file_name}")" <= 10485760 )); then
+                :
+              else
+                file_list+=("${files_num}")
+              fi
+            done
+            count=1
+            for file_name in $(ls -tr); do
+              if (( "$(wc -c < "${file_name}")" <= 10485760 )); then
+                :
+              else
+                num=$((count++))
+                threads="$(nproc)"
+                target_bytes="$((10 * 1024 * 1024))"
+                target_bytes_eff="$(awk -v t="${target_bytes}" 'BEGIN{printf("%d\n",t*0.99)}')"
+                aud_kbps=48
+                max_overhead=0.05
+                bpp_coef=0.06
+                dur="$(ffprobe -v error -show_entries format=duration -of default=nw=1:nk=1 "${file_name}")"
+                dur_s=${dur%.*};(( dur_s > 0 )) || dur_s=1
+                {
+                  progress_pb="$(mktemp)"
+                  pid_pb="$(mktemp)"
+                  nohup conv_progress.sh "${progress_pb}" ${num} ${#file_list[@]} "🔎Probing..." &
+                  echo "${!}" > "${pid_pb}" && \
+                  probe_log="$(mktemp)" && \
+                  t_sec="$(awk -v d="${dur:-0}" 'BEGIN{t=d*0.05;if(t<1.0)t=1.0;if(t>10.0)t=10.0;printf("%.2f\n",t)}')" && \
+                  mid_ss="$(awk -v d="${dur:-0}" -v t="${t_sec:-1}" 'BEGIN{ss=d/2.0-t/2.0;if(ss<0)ss=0;printf("%.2f\n",ss)}')"
+                  {
+                    ffmpeg -y -v info \
+                      -ss "${mid_ss}" -t "${t_sec}" -i "${file_name}" \
+                      -c:v libx265 -preset ultrafast -b:v 500k -maxrate 500k -bufsize 1M \
+                      -c:a libopus -b:a "${aud_kbps}k" -vbr on -compression_level 10 -application audio \
+                      -movflags +faststart -map_metadata -1 -map_chapters -1 -dn \
+                      -f mp4 /dev/null 2>&1 | \
+                    tee >(awk -f "${dir}/progress.awk" >> "${progress_pb}") \
+                        >(cat > "${probe_log}") > /dev/null
+                  }
+                  cat "${pid_pb}" | xargs kill -term 2>/dev/null || :
+                  mux_ov_pct="$(awk '/muxing overhead:/{val=$NF;gsub(/%/,"",val);print val}' "${probe_log}")"
+                  if [[ -n "${mux_ov_pct}" ]]; then
+                    extra="$(awk -v d="${dur_s}" 'BEGIN{e=0.005+(60.0/d)*0.001;if(e>0.010)e=0.010;printf("%.4f\n",e)}')"
+                    overhead="$(awk -v m="${mux_ov_pct:-0}" -v ex="${extra}" -v mx="${max_overhead}" 'BEGIN{v=(m/100.0)+ex;if(v>mx)v=mx;if(v<0.0)v=0.0;printf("%.4f\n",v)}')"
+                  else
+                    overhead="${max_overhead}"
+                  fi
+                }
+                {
+                  info="$(ffprobe -v error -select_streams v:0 -show_entries stream=width,height,avg_frame_rate -of csv=s=x:p=0 "${file_name}")"
+                  IFS="x" read -r w h fps_raw <<< "${info}"
+                  fps="$(awk -v r="${fps_raw}" 'BEGIN{n=split(r,a,"/");if(n==2 && a[2]>0){printf("%.6f\n",a[1]/a[2])}else if(n==1){printf("%.6f\n",a[1]+0.0)}else{printf("0.000000\n")}}')"
+                  max_vbps_from_size="$(awk -v t="${target_bytes_eff}" -v oh="${overhead}" -v a="${aud_kbps}" -v d="${dur_s}" 'BEGIN{tb=t*8;ab=a*1000*d;usable=(tb*(1.0-oh))-ab;printf("%d\n",usable/d)}')"
+                  calc_min_vbps="$(awk -v w="${w}" -v h="${h}" -v f="${fps}" -v c="${bpp_coef}" 'BEGIN{v=w*h*f*c;printf("%d\n",v)}')"
+                  if (( "${h}" >= 1080 )); then
+                    fixed_min_vbps=1200000
+                  elif (( "${h}" >= 720 )); then
+                    fixed_min_vbps=800000
+                  elif (( "${h}" >= 480 )); then
+                    fixed_min_vbps=400000
+                  else
+                    fixed_min_vbps=250000
+                  fi
+                  tmp_min_vbps="$(( calc_min_vbps > fixed_min_vbps ? calc_min_vbps : fixed_min_vbps ))"
+                  if (( tmp_min_vbps > max_vbps_from_size )); then
+                    min_vbps="${max_vbps_from_size}"
+                  else
+                    min_vbps="${tmp_min_vbps}"
+                  fi
+                  Bv="${min_vbps}"
+                  {
+                    progress_an="$(mktemp)"
+                    pid_an="$(mktemp)"
+                    nohup conv_progress.sh "${progress_an}" ${num} ${#file_list[@]} "🧪Analyzing..." &
+                    echo "${!}" > "${pid_an}" && \
+                    mkdir -p "${dir}/analyze" && \
+                    {
+                      ffmpeg -y \
+                        -i "${file_name}" \
+                        -threads "${threads}" \
+                        -c:v libx265 -preset ultrafast -b:v "${Bv}" -maxrate "${Bv}" -bufsize $(("${Bv}" * 2)) \
+                        -an \
+                        -pass 1 -passlogfile "${dir}/analyze/${file_name%.*}.log" \
+                        -f mp4 /dev/null 2>&1 | \
+                      awk -f "${dir}/progress.awk" >> "${progress_an}"
+                    }
+                    cat "${pid_an}" | xargs kill -term 2>/dev/null || :
+                  }
+                  {
+                    progress_cv="$(mktemp)"
+                    pid_cv="$(mktemp)"
+                    nohup conv_progress.sh "${progress_cv}" ${num} ${#file_list[@]} "🔁Converting..." &
+                    echo "${!}" > "${pid_cv}" && \
+                    mkdir -p "${dir}/conv" && \
+                    {
+                      ffmpeg -i "${file_name}" \
+                        -threads "${threads}" \
+                        -c:v libx265 -preset medium -b:v "${Bv}" -maxrate "${Bv}" -bufsize $(("${Bv}" * 2)) \
+                        -pix_fmt yuv420p -tag:v hvc1 \
+                        -c:a libopus -b:a "${aud_kbps}k" -vbr on -compression_level 10 -application audio \
+                        -movflags +faststart -map_metadata -1 -map_chapters -1 -dn \
+                        -pass 2 -passlogfile "${dir}/analyze/${file_name%.*}.log" \
+                        -fs 10MB \
+                        "${dir}/conv/${file_name%.*}.mp4" 2>&1 | \
+                      awk -f "${dir}/progress.awk" >> "${progress_cv}"
+                    }
+                    sleep 2
+                    cat "${pid_cv}" | xargs kill -term 2>/dev/null || :
+                  }
+                }
+              fi
+            done
+          fi
+      - name: Upload files
+        if: ${{ success() }}
+        id: upload
+        shell: bash
+        run: |
+          {
+            retry_curl.sh 15 2 -- \
+              -X POST \
+              ${{ secrets.ENDPOINT_URL }} \
+              -H "Accept: application/json" \
+              -H "Content-type: application/json" \
+              -m 18000 \
+              --retry 100 \
+              --retry-all-errors \
+              -d @- <<EOF
+            {
+              "status": "progress",
+              "number": ${{ github.run_number }},
+              "commandType": ${{ toJSON(github.event.client_payload.commandType) }},
+              "startTime": ${{ toJSON(github.event.client_payload.startTime) }},
+              "channel": ${{ toJSON(github.event.client_payload.channel) }},
+              "message": ${{ toJSON(matrix.message) }},
+              "token": ${{ toJSON(github.event.client_payload.token) }},
+              "link": ${{ toJSON(matrix.link) }},
+              "content": "⏫Uploading..."
+            }
+          EOF
+          } || :
+          dir=$(pwd) && \
+          cd download && \
+          IFS=$'\n' && \
+          files_num="$(ls | wc -l)" && \
+          if (( "${files_num}" > 1 )); then
+            for file_name in $(ls -tr); do
+              if (( "$(wc -c < "${file_name}")" <= 10485760 )); then
+                :
+              elif (( "$(wc -c < "${dir}/conv/${file_name%.*}.mp4")" <= 10485760 )); then
+                :
+              else
+                status="sizeover" && \
+                echo "status=${status}" >> "${GITHUB_OUTPUT}" && \
+                exit 2
+              fi
+            done
+            options=()
+            options+=(-F 'status=success')
+            options+=(-F 'number=${{ github.run_number }}')
+            options+=(-F 'commandType=${{ toJSON(github.event.client_payload.commandType) }}')
+            options+=(-F 'actionType=thread-multi')
+            options+=(-F 'channel=${{ toJSON(github.event.client_payload.channel) }}')
+            options+=(-F 'message=${{ toJSON(matrix.message) }}')
+            options+=(-F 'token=${{ toJSON(github.event.client_payload.token) }}')
+            options+=(-F 'link=${{ toJSON(matrix.link) }}')
+            options+=(-F 'startTime=${{ toJSON(github.event.client_payload.startTime) }}')
+            if (( "$(echo $(ls -l | awk 'NR>1{print $5}' | tr \\n +)0 | bc)" <= $(( 10485760 * "${files_num}" )) )); then
+              options+=(-F "convert=false")
+            else
+              options+=(-F "convert=true")
+            fi
+            index=0
+            list=()
+            for file_name in $(ls -tr); do
+              num=$((index++))
+              if (( "$(echo $(ls -l | awk 'NR>1{print $5}' | tr \\n +)0 | bc)" <= $(( 10485760 * "${files_num}" )) )); then
+                options+=(-F "name${num}=${file_name}")
+                options+=(-F "file${num}=@${file_name}")
+                list+=("${file_name}")
+              else
+                if (( "$(wc -c < "${file_name}")" <= 10485760 )); then
+                  options+=(-F "name${num}=${file_name}")
+                  options+=(-F "file${num}=@${file_name}")
+                  list+=("${file_name}")
+                else
+                  options+=(-F "name${num}=${file_name%.*}.mp4")
+                  options+=(-F "file${num}=@${dir}/conv/${file_name%.*}.mp4")
+                  list+=("${dir}/conv/${file_name%.*}.mp4")
+                fi
+              fi
+            done
+            total_size=$(echo $(echo "${list[@]}" | tr ' ' \\n | grep -v '^$' | xargs -I@ bash -c 'ls -l @' | awk '{print $5}' | grep -v '^$' | tr \\n '+')0 | bc)
+            echo "Total size: ${total_size}"
+            options+=(-F "size=${total_size}")
+            if (( "${total_size}" <= $(( 10485760 * "${files_num}" )) )); then
+              options+=(-F "oversize=false")
+            else
+              options+=(-F "oversize=true")
+            fi
+            retry=0 && \
+            flag=false && \
+            until "${flag}" || (( "${retry}" == 1000 )); do
+              echo "Retry count: ${retry}"
+              echo "Flag status: ${flag}"
+              retry_curl.sh 15 2 -- \
+                -X POST \
+                -H "Content-type: multipart/form-data" \
+                -m 18000 \
+                --retry 100 \
+                --retry-all-errors \
+                "${options[@]}" \
+                ${{ secrets.ENDPOINT_URL }} && \
+              flag=true || \
+              {
+                ((retry++)) || true
+              }
+            done
+          else
+            file_name="$(ls)" && \
+            if (( "$(wc -c < "${file_name}")" <= 10485760 )); then
+              echo "Total size: $(wc -c < "${file_name}")"
+              retry=0 && \
+              flag=false && \
+              until "${flag}" || (( "${retry}" == 1000 )); do
+                echo "Retry count: ${retry}"
+                echo "Flag status: ${flag}"
+                retry_curl.sh 15 2 -- \
+                  -X POST \
+                  -H "Content-type: multipart/form-data" \
+                  -m 18000 \
+                  --retry 100 \
+                  --retry-all-errors \
+                  -F "status=success" \
+                  -F 'number=${{ github.run_number }}' \
+                  -F "commandType=${{ toJSON(github.event.client_payload.commandType) }}" \
+                  -F "actionType=thread-single" \
+                  -F "convert=false" \
+                  -F "oversize=false" \
+                  -F "size=$(wc -c < "${file_name}")" \
+                  -F 'startTime=${{ toJSON(github.event.client_payload.startTime) }}' \
+                  -F 'channel=${{ toJSON(github.event.client_payload.channel) }}' \
+                  -F 'message=${{ toJSON(matrix.message) }}' \
+                  -F 'token=${{ toJSON(github.event.client_payload.token) }}' \
+                  -F 'link=${{ toJSON(matrix.link) }}' \
+                  -F "name1=${file_name}" \
+                  -F "file1=@${file_name}" \
+                  ${{ secrets.ENDPOINT_URL }} && \
+                flag=true || \
+                {
+                  ((retry++)) || true
+                }
+              done
+            else
+              total_size=$(wc -c < "${dir}/conv/${file_name%.*}.mp4")
+              echo "Total size: ${total_size}"
+              if (( "${total_size}" <= 10485760 )); then
+                retry=0 && \
+                flag=false && \
+                until "${flag}" || (( "${retry}" == 1000 )); do
+                  echo "Retry count: ${retry}"
+                  echo "Flag status: ${flag}"
+                  retry_curl.sh 15 2 -- \
+                    -X POST \
+                    -H "Content-type: multipart/form-data" \
+                    -m 18000 \
+                    --retry 100 \
+                    --retry-all-errors \
+                    -F "status=success" \
+                    -F 'number=${{ github.run_number }}' \
+                    -F "commandType=${{ toJSON(github.event.client_payload.commandType) }}" \
+                    -F "actionType=thread-single" \
+                    -F "convert=true" \
+                    -F "oversize=false" \
+                    -F "size=${total_size}" \
+                    -F 'startTime=${{ toJSON(github.event.client_payload.startTime) }}' \
+                    -F 'channel=${{ toJSON(github.event.client_payload.channel) }}' \
+                    -F 'message=${{ toJSON(matrix.message) }}' \
+                    -F 'token=${{ toJSON(github.event.client_payload.token) }}' \
+                    -F 'link=${{ toJSON(matrix.link) }}' \
+                    -F "name1=${file_name%.*}.mp4" \
+                    -F "file1=@${dir}/conv/${file_name%.*}.mp4" \
+                    ${{ secrets.ENDPOINT_URL }} && \
+                  flag=true || \
+                  {
+                    ((retry++)) || true
+                  }
+                done
+              else
+                status="sizeover" && \
+                echo "status=${status}" >> "${GITHUB_OUTPUT}" && \
+                exit 2
+              fi
+            fi
+          fi
+      - name: Link has expired
+        if: >-
+          ${{
+            failure() &&
+            steps.link_status.outputs.status == 'notfound' &&
+            steps.download.outputs.status == '' &&
+            steps.upload.outputs.status == ''
+          }}
+        shell: bash
+        run: |
+          retry_curl.sh 15 2 -- \
+            -X POST \
+            ${{ secrets.ENDPOINT_URL }} \
+            -H "Accept: application/json" \
+            -H "Content-type: application/json" \
+            -m 18000 \
+            --retry 100 \
+            --retry-all-errors \
+            -d @- <<EOF
+          {
+            "status": "failure",
+            "number": ${{ github.run_number }},
+            "commandType": ${{ toJSON(github.event.client_payload.commandType) }},
+            "startTime": ${{ toJSON(github.event.client_payload.startTime) }},
+            "channel": ${{ toJSON(github.event.client_payload.channel) }},
+            "message": ${{ toJSON(matrix.message) }},
+            "token": ${{ toJSON(github.event.client_payload.token) }},
+            "link": ${{ toJSON(matrix.link) }},
+            "content": "Sorry! This link has expired."
+          }
+          EOF
+      - name: Video file not found
+        if: >-
+          ${{
+            failure() &&
+            steps.link_status.outputs.status == '' &&
+            steps.download.outputs.status == 'notvideo' &&
+            steps.upload.outputs.status == ''
+          }}
+        shell: bash
+        run: |
+          retry_curl.sh 15 2 -- \
+            -X POST \
+            ${{ secrets.ENDPOINT_URL }} \
+            -H "Accept: application/json" \
+            -H "Content-type: application/json" \
+            -m 18000 \
+            --retry 100 \
+            --retry-all-errors \
+            -d @- <<EOF
+          {
+            "status": "failure",
+            "number": ${{ github.run_number }},
+            "commandType": ${{ toJSON(github.event.client_payload.commandType) }},
+            "startTime": ${{ toJSON(github.event.client_payload.startTime) }},
+            "channel": ${{ toJSON(github.event.client_payload.channel) }},
+            "message": ${{ toJSON(matrix.message) }},
+            "token": ${{ toJSON(github.event.client_payload.token) }},
+            "link": ${{ toJSON(matrix.link) }},
+            "content": "Sorry, The video file did not exist at this link!"
+          }
+          EOF
+      - name: Uploaded file size exceeded
+        if: >-
+          ${{
+            failure() &&
+            steps.link_status.outputs.status == '' &&
+            steps.download.outputs.status == '' &&
+            steps.upload.outputs.status == 'sizeover'
+          }}
+        shell: bash
+        run: |
+          dir=$(pwd) && \
+          cd download && \
+          if (( "$(ls | wc -l)" == 1 )); then
+            original_size="$(ls -trlh | awk 'NR>1{printf "%sB", $5}')"
+          else
+            original_size="$(ls -trlh | awk 'NR==1{printf "%sB", $2}')"
+          fi && \
+          cd ${dir}/conv && \
+          if (( "$(ls | wc -l)" == 1 )); then
+            converted_size="$(ls -trlh | awk 'NR>1{printf "%sB", $5}')"
+          else
+            converted_size="$(ls -trlh | awk 'NR==1{printf "%sB", $2}')"
+          fi && \
+          retry_curl.sh 15 2 -- \
+            -X POST \
+            ${{ secrets.ENDPOINT_URL }} \
+            -H "Accept: application/json" \
+            -H "Content-type: application/json" \
+            -m 18000 \
+            --retry 100 \
+            --retry-all-errors \
+            -d @- <<EOF
+          {
+            "status": "failure",
+            "number": ${{ github.run_number }},
+            "commandType": ${{ toJSON(github.event.client_payload.commandType) }},
+            "startTime": ${{ toJSON(github.event.client_payload.startTime) }},
+            "channel": ${{ toJSON(github.event.client_payload.channel) }},
+            "message": ${{ toJSON(matrix.message) }},
+            "token": ${{ toJSON(github.event.client_payload.token) }},
+            "link": ${{ toJSON(matrix.link) }},
+            "content": "Sorry, The file could not be uploaded because its size exceeds 10MB!\nFile Size: ${original_size} -> ${converted_size}"
+          }
+          EOF
+      - name: Download timed out
+        if: >-
+          ${{
+            failure() &&
+            steps.link_status.outputs.status == '' &&
+            steps.download.outputs.status == '' &&
+            steps.upload.outputs.status == ''
+          }}
+        shell: bash
+        run: |
+          sleep 5 && \
+          retry_curl.sh 15 2 -- \
+            -X POST \
+            ${{ secrets.ENDPOINT_URL }} \
+            -H "Accept: application/json" \
+            -H "Content-type: application/json" \
+            -m 18000 \
+            --retry 100 \
+            --retry-all-errors \
+            -d @- <<EOF
+          {
+            "status": "failure",
+            "number": ${{ github.run_number }},
+            "commandType": ${{ toJSON(github.event.client_payload.commandType) }},
+            "startTime": ${{ toJSON(github.event.client_payload.startTime) }},
+            "channel": ${{ toJSON(github.event.client_payload.channel) }},
+            "message": ${{ toJSON(matrix.message) }},
+            "token": ${{ toJSON(github.event.client_payload.token) }},
+            "link": ${{ toJSON(matrix.link) }},
+            "content": "Sorry! Processing time exceeded 10 minutes and timed out."
+          }
+          EOF
+      - name: Cleanup temp files
+        if: ${{ always() && !cancelled() }}
+        shell: bash
+        run: |
+          echo "🧹 Cleaning up temporary files..."
+          rm -rf ./download
+          rm -rf ./conv
+          rm -rf ./analyze
+          rm -f ./cookie.txt
+          rm -f ./secrets.txt
+          rm -f ./progress.awk
+          rm -f /usr/local/bin/conv_progress.sh
+          rm -f /usr/local/bin/retry_curl.sh
+          rm -f /usr/local/bin/post_process.sh

--- a/src/bot/bot.ts
+++ b/src/bot/bot.ts
@@ -3,6 +3,7 @@ import { Secrets } from "@libs";
 import { Match } from "functional";
 import { Bot, createBot, Intents, Interaction } from "discordeno";
 import { interactionCreate } from "@bot/interactionCreate.ts";
+import { threadInteractionCreate } from "@bot/threadInteractionCreate.ts";
 
 const bot: Bot = createBot({
   token: Secrets.DISCORD_TOKEN,
@@ -16,6 +17,7 @@ const bot: Bot = createBot({
 
 await bot.helpers.createGlobalApplicationCommand(Commands.dlCommand);
 await bot.helpers.createGlobalApplicationCommand(Commands.dlSpoilerCommand);
+await bot.helpers.createGlobalApplicationCommand(Commands.threadDlCommand);
 
 /**
  * Handles the interactionCreate event for the bot.
@@ -48,6 +50,13 @@ bot.events.interactionCreate = async (
       async (commandType: string): Promise<void> => {
         props.commandType = commandType;
         await interactionCreate(props);
+      },
+    )
+    .with(
+      Commands.threadDlCommand.name,
+      async (commandType: string): Promise<void> => {
+        props.commandType = commandType;
+        await threadInteractionCreate(props);
       },
     )
     .otherwise((): void => {});

--- a/src/bot/threadInteractionCreate.ts
+++ b/src/bot/threadInteractionCreate.ts
@@ -1,0 +1,167 @@
+import { If } from "functional";
+import { KyResponse } from "ky";
+import {
+  Bot,
+  ChannelTypes,
+  EditMessage,
+  Interaction,
+  InteractionResponseTypes,
+  Message,
+} from "discordeno";
+import { Messages, Constants, isUrl, webhookThread } from "@libs";
+
+type InteractionData = Exclude<Pick<Interaction, "data">["data"], undefined>;
+type InteractionOption = Exclude<
+  Pick<InteractionData, "options">["options"],
+  undefined
+>[number];
+
+const NAME_OPTION = "name";
+const URL_OPTION = "url";
+
+/**
+ * Resolves a string-typed option from the interaction data by name.
+ *
+ * @param {InteractionOption[] | undefined} options - The options array of the interaction.
+ * @param {string} name - The name of the option to extract.
+ * @return {string} The string value of the matched option, or empty string if not found.
+ */
+const pickOption = (
+  options: InteractionOption[] | undefined,
+  name: string,
+): string =>
+  (options ?? []).find(
+    (i: InteractionOption): boolean => i.name === name,
+  )?.value as string ?? "";
+
+/**
+ * Handles the `/threaddl` interaction by creating a Discord thread on the
+ * source channel, queueing one message per URL inside the thread, and firing
+ * a single `repository_dispatch` (event_type=`thread-download`) so the
+ * GitHub Actions matrix workflow can fan-out per-URL processing in parallel.
+ *
+ * @param {object} props - The handler props bag.
+ * @param {Bot} props.b - The bot instance.
+ * @param {InteractionData} props.data - The interaction data object.
+ * @param {Interaction} props.interaction - The interaction object.
+ * @param {string} props.commandType - The command type (`threaddl`).
+ * @return {Promise<void>} A promise that resolves when fan-out completes.
+ */
+export const threadInteractionCreate = async (props: {
+  b: Bot;
+  data: InteractionData;
+  interaction: Interaction;
+  commandType: string;
+}): Promise<void> => {
+  const threadName: string = pickOption(props.data.options, NAME_OPTION);
+  const rawUrl: string = pickOption(props.data.options, URL_OPTION);
+  const contents: string[] = rawUrl.split(" ").filter((i: string): boolean =>
+    i.length > 0,
+  );
+
+  await props.b.helpers.sendInteractionResponse(
+    props.interaction.id,
+    props.interaction.token,
+    {
+      type: InteractionResponseTypes.DeferredChannelMessageWithSource,
+    },
+  );
+
+  const allValid: boolean =
+    contents.length > 0 &&
+    contents.every((i: string): boolean => isUrl(i)) &&
+    threadName.length > 0;
+
+  await If(
+    !allValid,
+    async (): Promise<void> => {
+      await props.b.helpers.sendFollowupMessage(props.interaction.token, {
+        type: InteractionResponseTypes.ChannelMessageWithSource,
+        data: Messages.createErrorMessage({
+          description: contents.length > 0 ? contents.join("\n") : rawUrl,
+        }),
+      });
+    },
+  ).else(async (): Promise<void> => {
+    if (!props.interaction.channelId) {
+      await props.b.helpers.sendFollowupMessage(props.interaction.token, {
+        type: InteractionResponseTypes.ChannelMessageWithSource,
+        data: Messages.createErrorMessage({
+          description: "This command must be used in a guild text channel.",
+        }),
+      });
+      return;
+    }
+
+    const thread = await props.b.helpers
+      .startThreadWithoutMessage(props.interaction.channelId, {
+        name: threadName,
+        autoArchiveDuration: Constants.Thread.AUTO_ARCHIVE_DURATION,
+        type: Constants.Thread.TYPE as ChannelTypes.PublicThread,
+      })
+      .catch(async (e: Error): Promise<null> => {
+        await props.b.helpers.sendFollowupMessage(props.interaction.token, {
+          type: InteractionResponseTypes.ChannelMessageWithSource,
+          data: Messages.createErrorMessage({
+            description: `Failed to create thread: ${e.message}`,
+          }),
+        });
+        return null;
+      });
+    if (!thread) return;
+
+    await props.b.helpers.sendFollowupMessage(props.interaction.token, {
+      type: InteractionResponseTypes.ChannelMessageWithSource,
+      data: {
+        content: `🧵 Created thread <#${thread.id}> for ${contents.length} URL(s).`,
+      },
+    });
+
+    const queueResults = await Promise.all(
+      contents.map(
+        async (
+          content: string,
+        ): Promise<{ link: string; message: string } | null> =>
+          await props.b.helpers
+            .sendMessage(
+              thread.id,
+              Messages.createProgressMessage({
+                content: `**🕑Queuing...**`,
+                link: content,
+              }),
+            )
+            .then((m: Message): { link: string; message: string } => ({
+              link: content,
+              message: `${m.id}`,
+            }))
+            .catch((): null => null),
+      ),
+    );
+    const links = queueResults.filter(
+      (i): i is { link: string; message: string } => i !== null,
+    );
+    if (links.length === 0) return;
+
+    await webhookThread({
+      commandType: props.commandType,
+      links,
+      channelId: thread.id,
+      token: props.interaction.token,
+      startTime: new Date().getTime().toString(),
+    }).catch(async (e: Error): Promise<KyResponse | void> => {
+      await Promise.all(
+        links.map(
+          async (i: { link: string; message: string }): Promise<Message> =>
+            await props.b.helpers.editMessage(
+              thread.id,
+              BigInt(i.message),
+              Messages.createErrorMessage({
+                link: i.link,
+                description: e.message,
+              }) as EditMessage,
+            ),
+        ),
+      );
+    });
+  });
+};

--- a/src/bot/threadInteractionCreate.ts
+++ b/src/bot/threadInteractionCreate.ts
@@ -83,7 +83,11 @@ export const threadInteractionCreate = async (props: {
       });
     },
   ).else(async (): Promise<void> => {
-    if (!props.interaction.channelId) {
+    // Threads can only be created inside a guild text/announcement/forum
+    // channel. `interaction.channelId` is populated for DM interactions too
+    // (it's the DM channel ID), so also gate on `guildId` to ensure we are
+    // running in a guild context before calling `startThreadWithoutMessage`.
+    if (!props.interaction.channelId || !props.interaction.guildId) {
       await props.b.helpers.sendFollowupMessage(props.interaction.token, {
         type: InteractionResponseTypes.ChannelMessageWithSource,
         data: Messages.createErrorMessage({

--- a/src/libs/constants.ts
+++ b/src/libs/constants.ts
@@ -45,6 +45,7 @@ export const Constants = {
   Webhook: {
     Json: {
       EVENT_TYPE: "download",
+      EVENT_TYPE_THREAD: "thread-download",
       ClientPayload: {
         CommandType: {
           DOWNLOAD: "dl",
@@ -57,6 +58,10 @@ export const Constants = {
       ACCEPT: "application/vnd.github.everest-preview+json",
     },
   },
+  Thread: {
+    AUTO_ARCHIVE_DURATION: 1440,
+    TYPE: 11,
+  },
   CallbackObject: {
     Status: {
       SUCCESS: "success",
@@ -66,10 +71,13 @@ export const Constants = {
     commandType: {
       DL: "dl",
       DL_SPOILER: "dl-spoiler",
+      THREAD_DL: "threaddl",
     },
     actionType: {
       SINGLE: "single",
       MULTI: "multi",
+      THREAD_SINGLE: "thread-single",
+      THREAD_MULTI: "thread-multi",
     },
     Oversize: {
       TRUE: "true",

--- a/src/libs/custom.ts
+++ b/src/libs/custom.ts
@@ -28,7 +28,29 @@ export const Custom = {
           Constants.CallbackObject.actionType.MULTI,
         ],
       },
+      ThreadDl: {
+        Single: [
+          Constants.CallbackObject.Status.SUCCESS,
+          Constants.CallbackObject.commandType.THREAD_DL,
+          Constants.CallbackObject.actionType.THREAD_SINGLE,
+        ],
+        Multi: [
+          Constants.CallbackObject.Status.SUCCESS,
+          Constants.CallbackObject.commandType.THREAD_DL,
+          Constants.CallbackObject.actionType.THREAD_MULTI,
+        ],
+      },
     },
+    FailureThread: [
+      Constants.CallbackObject.Status.FAILURE,
+      Constants.CallbackObject.commandType.THREAD_DL,
+      P.nullish,
+    ],
+    ProgressThread: [
+      Constants.CallbackObject.Status.PROGRESS,
+      Constants.CallbackObject.commandType.THREAD_DL,
+      P.nullish,
+    ],
     Failure: [Constants.CallbackObject.Status.FAILURE, P.nullish, P.nullish],
     Progress: [Constants.CallbackObject.Status.PROGRESS, P.nullish, P.nullish],
     InvalidPost: [P.nullish, P.nullish, P.nullish],

--- a/src/libs/index.ts
+++ b/src/libs/index.ts
@@ -1,6 +1,6 @@
 export { isUrl } from "@libs/isUrl.ts";
 export { isEmptyObj } from "@libs/isEmptyObj.ts";
-export { webhook } from "@libs/webhook.ts";
+export { webhook, webhookThread } from "@libs/webhook.ts";
 export { Contents } from "@libs/contents/index.ts";
 export { Constants } from "@libs/constants.ts";
 export { Secrets } from "@libs/secrets.ts";

--- a/src/libs/webhook.ts
+++ b/src/libs/webhook.ts
@@ -31,3 +31,34 @@ export const webhook = async (message: {
       Accept: Constants.Webhook.Headers.ACCEPT,
     },
   });
+
+/**
+ * Sends a thread-download webhook with multiple links so the matrix workflow
+ * can fan-out per-URL processing in parallel.
+ *
+ * @param {object} payload - The thread payload containing links and the target thread channel.
+ * @return {Promise<KyResponse>} A promise that resolves with the response from the webhook request.
+ */
+export const webhookThread = async (payload: {
+  commandType: string;
+  links: { link: string; message: string }[];
+  channelId: bigint;
+  token: string;
+  startTime: string;
+}): Promise<KyResponse> =>
+  await ky.post(Secrets.DISPATCH_URL, {
+    json: {
+      event_type: Constants.Webhook.Json.EVENT_TYPE_THREAD,
+      client_payload: {
+        commandType: payload.commandType,
+        channel: `${payload.channelId}`,
+        token: payload.token,
+        startTime: payload.startTime,
+        links: payload.links,
+      },
+    },
+    headers: {
+      Authorization: `token ${Secrets.GITHUB_TOKEN}`,
+      Accept: Constants.Webhook.Headers.ACCEPT,
+    },
+  });

--- a/src/router/callback.ts
+++ b/src/router/callback.ts
@@ -86,6 +86,32 @@ callback.post(
           }),
       )
       .with(
+        callbackPattern.Success.ThreadDl.Single,
+        (): Promise<Response> =>
+          Functions.callbackSuccessFunctions.success.threadDl.single({
+            c,
+            body,
+          }),
+      )
+      .with(
+        callbackPattern.Success.ThreadDl.Multi,
+        (): Promise<Response> =>
+          Functions.callbackSuccessFunctions.success.threadDl.multi({
+            c,
+            body,
+          }),
+      )
+      .with(
+        callbackPattern.ProgressThread,
+        (): Promise<Response> =>
+          Functions.callbackProgressFunctions.progress({ c, body }),
+      )
+      .with(
+        callbackPattern.FailureThread,
+        (): Promise<Response> =>
+          Functions.callbackFailureFunctions.failure({ c, body }),
+      )
+      .with(
         callbackPattern.Progress,
         (): Promise<Response> =>
           Functions.callbackProgressFunctions.progress({ c, body }),

--- a/src/router/functions/callbackFailureFunctions.ts
+++ b/src/router/functions/callbackFailureFunctions.ts
@@ -21,8 +21,10 @@ const callbackFailureFunctions: CallbackTypes.Functions.callbackFailure = {
     const runTime: number =
       new Date().getTime() - Number(infoObject.body!.startTime);
     const useThread: boolean = infoObject.body!.commandType === threadDl;
+    // editMessage (thread mode) is not bound by the 15-min interaction-token
+    // window, so always edit the placeholder when running in a thread.
     const isEditOriginalMessage: boolean =
-      runTime <= Constants.EDIT_FOLLOWUP_MESSAGE_TIME_LIMIT;
+      useThread || runTime <= Constants.EDIT_FOLLOWUP_MESSAGE_TIME_LIMIT;
     return match(isEditOriginalMessage)
       .with(
         true,

--- a/src/router/functions/callbackFailureFunctions.ts
+++ b/src/router/functions/callbackFailureFunctions.ts
@@ -1,5 +1,6 @@
 import bot from "@bot/bot.ts";
 import { match } from "ts-pattern";
+import { EditMessage } from "discordeno";
 import { Constants, Messages } from "@libs";
 import { CallbackTypes } from "@router/types/callbackTypes.ts";
 
@@ -7,6 +8,7 @@ type InfoObject<T extends string> = CallbackTypes.infoObjectType<T>;
 
 const noContent = Constants.HttpStatus.NO_CONTENT;
 const internalServerError = Constants.HttpStatus.INTERNAL_SERVER_ERROR;
+const threadDl = Constants.CallbackObject.commandType.THREAD_DL;
 
 const callbackFailureFunctions: CallbackTypes.Functions.callbackFailure = {
   /**
@@ -18,23 +20,35 @@ const callbackFailureFunctions: CallbackTypes.Functions.callbackFailure = {
   failure: <T extends string>(infoObject: InfoObject<T>): Promise<Response> => {
     const runTime: number =
       new Date().getTime() - Number(infoObject.body!.startTime);
-    const isEditFollowupMessage: boolean =
+    const useThread: boolean = infoObject.body!.commandType === threadDl;
+    const isEditOriginalMessage: boolean =
       runTime <= Constants.EDIT_FOLLOWUP_MESSAGE_TIME_LIMIT;
-    return match(isEditFollowupMessage)
+    return match(isEditOriginalMessage)
       .with(
         true,
-        async (): Promise<Response> =>
-          await bot.helpers
-            .editFollowupMessage(
-              infoObject.body!.token,
-              infoObject.body!.message,
-              Messages.createFailureMessage({
-                runNumber: infoObject.body!.number,
-                runTime: runTime,
-                link: infoObject.body!.link,
-                content: infoObject.body!.content!,
-              })
-            )
+        (): Promise<Response> =>
+          (useThread
+            ? bot.helpers.editMessage(
+                infoObject.body!.channel,
+                infoObject.body!.message,
+                Messages.createFailureMessage({
+                  runNumber: infoObject.body!.number,
+                  runTime: runTime,
+                  link: infoObject.body!.link,
+                  content: infoObject.body!.content!,
+                }) as EditMessage
+              )
+            : bot.helpers.editFollowupMessage(
+                infoObject.body!.token,
+                infoObject.body!.message,
+                Messages.createFailureMessage({
+                  runNumber: infoObject.body!.number,
+                  runTime: runTime,
+                  link: infoObject.body!.link,
+                  content: infoObject.body!.content!,
+                })
+              )
+          )
             .then(
               (): Response => infoObject.c.body(null, { status: noContent })
             )

--- a/src/router/functions/callbackProgressFunctions.ts
+++ b/src/router/functions/callbackProgressFunctions.ts
@@ -23,8 +23,10 @@ const callbackProgressFunctions: CallbackTypes.Functions.callbackProgress = {
     const runTime: number =
       new Date().getTime() - Number(infoObject.body!.startTime);
     const useThread: boolean = infoObject.body!.commandType === threadDl;
+    // editMessage (thread mode) is not bound by the 15-min interaction-token
+    // window, so always edit the placeholder when running in a thread.
     const isEditOriginalMessage: boolean =
-      runTime <= Constants.EDIT_FOLLOWUP_MESSAGE_TIME_LIMIT;
+      useThread || runTime <= Constants.EDIT_FOLLOWUP_MESSAGE_TIME_LIMIT;
     return match(isEditOriginalMessage)
       .with(
         true,

--- a/src/router/functions/callbackProgressFunctions.ts
+++ b/src/router/functions/callbackProgressFunctions.ts
@@ -1,5 +1,6 @@
 import bot from "@bot/bot.ts";
 import { match } from "ts-pattern";
+import { EditMessage } from "discordeno";
 import { Constants, Messages } from "@libs";
 import { CallbackTypes } from "@router/types/callbackTypes.ts";
 
@@ -7,6 +8,7 @@ type InfoObject<T extends string> = CallbackTypes.infoObjectType<T>;
 
 const noContent = Constants.HttpStatus.NO_CONTENT;
 const internalServerError = Constants.HttpStatus.INTERNAL_SERVER_ERROR;
+const threadDl = Constants.CallbackObject.commandType.THREAD_DL;
 
 const callbackProgressFunctions: CallbackTypes.Functions.callbackProgress = {
   /**
@@ -20,23 +22,35 @@ const callbackProgressFunctions: CallbackTypes.Functions.callbackProgress = {
   ): Promise<Response> => {
     const runTime: number =
       new Date().getTime() - Number(infoObject.body!.startTime);
-    const isEditFollowupMessage: boolean =
+    const useThread: boolean = infoObject.body!.commandType === threadDl;
+    const isEditOriginalMessage: boolean =
       runTime <= Constants.EDIT_FOLLOWUP_MESSAGE_TIME_LIMIT;
-    return match(isEditFollowupMessage)
+    return match(isEditOriginalMessage)
       .with(
         true,
-        async (): Promise<Response> =>
-          await bot.helpers
-            .editFollowupMessage(
-              infoObject.body!.token,
-              infoObject.body!.message,
-              Messages.createProgressMessage({
-                runNumber: infoObject.body!.number,
-                runTime: runTime,
-                link: infoObject.body!.link,
-                content: infoObject.body!.content!,
-              })
-            )
+        (): Promise<Response> =>
+          (useThread
+            ? bot.helpers.editMessage(
+                infoObject.body!.channel,
+                infoObject.body!.message,
+                Messages.createProgressMessage({
+                  runNumber: infoObject.body!.number,
+                  runTime: runTime,
+                  link: infoObject.body!.link,
+                  content: infoObject.body!.content!,
+                }) as EditMessage
+              )
+            : bot.helpers.editFollowupMessage(
+                infoObject.body!.token,
+                infoObject.body!.message,
+                Messages.createProgressMessage({
+                  runNumber: infoObject.body!.number,
+                  runTime: runTime,
+                  link: infoObject.body!.link,
+                  content: infoObject.body!.content!,
+                })
+              )
+          )
             .then(
               (): Response => infoObject.c.body(null, { status: noContent })
             )

--- a/src/router/functions/callbackSuccessFunctions.ts
+++ b/src/router/functions/callbackSuccessFunctions.ts
@@ -7,6 +7,132 @@ type InfoObject<T extends string> = CallbackTypes.infoObjectType<T>;
 const noContent = Constants.HttpStatus.NO_CONTENT;
 const serverError = Constants.HttpStatus.INTERNAL_SERVER_ERROR;
 
+/**
+ * Common single-file success handler. The `useThread` flag controls whether
+ * the message is edited in-place via `editMessage` (thread mode) or via
+ * `editFollowupMessage` (interaction follow-up mode).
+ */
+const handleSingleSuccess = async <T extends string>(
+  infoObject: InfoObject<T>,
+  spoiler: boolean,
+  useThread: boolean,
+): Promise<Response> => {
+  if (!infoObject.body)
+    return infoObject.c.body(null, { status: serverError });
+  let filesObject = await Contents.singleFileContent(infoObject.body)
+    .then((i) => i)
+    .catch(() => null);
+  try {
+    if (!filesObject)
+      return infoObject.c.body(null, { status: serverError });
+    return await SendMessages.successMessage
+      .singleFile({
+        token: infoObject.body.token,
+        channelId: infoObject.body.channel,
+        messageId: infoObject.body.message,
+        runNumber: infoObject.body.number,
+        startTime: infoObject.body.startTime,
+        totalSize: infoObject.body.size!,
+        fileName: filesObject.fileName,
+        link: infoObject.body.link,
+        file: filesObject.blobData,
+        oversize: infoObject.body.oversize!,
+        spoiler,
+        useThread,
+      })
+      .then(
+        (): Response => infoObject.c.body(null, { status: noContent }),
+      )
+      .catch(
+        (): Response => infoObject.c.body(null, { status: serverError }),
+      );
+  } catch (e: unknown) {
+    return await SendMessages.errorMessage({
+      token: infoObject.body.token,
+      channel: infoObject.body.channel,
+      message: infoObject.body.message,
+      number: infoObject.body.number,
+      link: infoObject.body.link,
+      description: (e as Error).message,
+      startTime: infoObject.body.startTime,
+      oversize: infoObject.body.oversize!,
+      useThread,
+    })
+      .then(
+        (): Response => infoObject.c.body(null, { status: noContent }),
+      )
+      .catch(
+        (): Response => infoObject.c.body(null, { status: serverError }),
+      );
+  } finally {
+    infoObject.body = null;
+    filesObject = null;
+  }
+};
+
+/**
+ * Common multi-file success handler. The `useThread` flag controls whether
+ * the message is edited in-place via `editMessage` (thread mode) or via
+ * `editFollowupMessage` (interaction follow-up mode).
+ */
+const handleMultiSuccess = async <T extends string>(
+  infoObject: InfoObject<T>,
+  spoiler: boolean,
+  useThread: boolean,
+): Promise<Response> => {
+  if (!infoObject.body)
+    return infoObject.c.body(null, { status: serverError });
+  let multiFilesObject = await Contents.multiFilesContent(infoObject.body)
+    .then((i) => i)
+    .catch(() => null);
+  try {
+    if (!multiFilesObject)
+      return infoObject.c.body(null, { status: serverError });
+    return await SendMessages.successMessage
+      .multiFiles({
+        token: infoObject.body.token,
+        channelId: infoObject.body.channel,
+        messageId: infoObject.body.message,
+        runNumber: infoObject.body.number,
+        startTime: infoObject.body.startTime,
+        totalSize: infoObject.body.size!,
+        fileNamesArray: multiFilesObject.fileNamesArray,
+        link: infoObject.body.link,
+        filesArray: multiFilesObject.filesArray,
+        oversize: infoObject.body.oversize!,
+        spoiler,
+        useThread,
+      })
+      .then(
+        (): Response => infoObject.c.body(null, { status: noContent }),
+      )
+      .catch(
+        (): Response => infoObject.c.body(null, { status: serverError }),
+      );
+  } catch (e: unknown) {
+    return await SendMessages.errorMessage({
+      token: infoObject.body.token,
+      channel: infoObject.body.channel,
+      message: infoObject.body.message,
+      number: infoObject.body.number,
+      link: infoObject.body.link,
+      description: (e as Error).message,
+      startTime: infoObject.body.startTime,
+      oversize: infoObject.body.oversize!,
+      useThread,
+    })
+      .then(
+        (): Response => infoObject.c.body(null, { status: noContent }),
+      )
+      .catch(
+        (): Response => infoObject.c.body(null, { status: serverError }),
+      );
+  } finally {
+    infoObject.body = null;
+    multiFilesObject = null;
+  }
+};
+
 const callbackSuccessFunctions: CallbackTypes.Functions.callbackSuccess = {
   success: {
     dl: {
@@ -16,118 +142,18 @@ const callbackSuccessFunctions: CallbackTypes.Functions.callbackSuccess = {
        * @param {InfoObject<T>} infoObject - The information object containing the necessary data for the callback success event.
        * @return {Promise<Response>} A promise that resolves to a Response object.
        */
-      single: async <T extends string>(
+      single: <T extends string>(
         infoObject: InfoObject<T>,
-      ): Promise<Response> => {
-        if (!infoObject.body)
-          return infoObject.c.body(null, { status: serverError });
-        let filesObject = await Contents.singleFileContent(infoObject.body)
-          .then((i) => i)
-          .catch(() => null);
-        try {
-          if (!filesObject)
-            return infoObject.c.body(null, { status: serverError });
-          return await SendMessages.successMessage
-            .singleFile({
-              token: infoObject.body.token,
-              channelId: infoObject.body.channel,
-              messageId: infoObject.body.message,
-              runNumber: infoObject.body.number,
-              startTime: infoObject.body.startTime,
-              totalSize: infoObject.body.size!,
-              fileName: filesObject.fileName,
-              link: infoObject.body.link,
-              file: filesObject.blobData,
-              oversize: infoObject.body.oversize!,
-              spoiler: false,
-            })
-            .then(
-              (): Response => infoObject.c.body(null, { status: noContent }),
-            )
-            .catch(
-              (): Response => infoObject.c.body(null, { status: serverError }),
-            );
-        } catch (e: unknown) {
-          return await SendMessages.errorMessage({
-            token: infoObject.body.token,
-            channel: infoObject.body.channel,
-            message: infoObject.body.message,
-            number: infoObject.body.number,
-            link: infoObject.body.link,
-            description: (e as Error).message,
-            startTime: infoObject.body.startTime,
-            oversize: infoObject.body.oversize!,
-          })
-            .then(
-              (): Response => infoObject.c.body(null, { status: noContent }),
-            )
-            .catch(
-              (): Response => infoObject.c.body(null, { status: serverError }),
-            );
-        } finally {
-          infoObject.body = null;
-          filesObject = null;
-        }
-      },
+      ): Promise<Response> => handleSingleSuccess(infoObject, false, false),
       /**
        * Asynchronously handles a multi callback success event.
        *
        * @param {InfoObject<T>} infoObject - The information object containing the necessary data for the callback success event.
        * @return {Promise<Response>} A promise that resolves to a Response object.
        */
-      multi: async <T extends string>(
+      multi: <T extends string>(
         infoObject: InfoObject<T>,
-      ): Promise<Response> => {
-        if (!infoObject.body)
-          return infoObject.c.body(null, { status: serverError });
-        let multiFilesObject = await Contents.multiFilesContent(infoObject.body)
-          .then((i) => i)
-          .catch(() => null);
-        try {
-          if (!multiFilesObject)
-            return infoObject.c.body(null, { status: serverError });
-          return await SendMessages.successMessage
-            .multiFiles({
-              token: infoObject.body.token,
-              channelId: infoObject.body.channel,
-              messageId: infoObject.body.message,
-              runNumber: infoObject.body.number,
-              startTime: infoObject.body.startTime,
-              totalSize: infoObject.body.size!,
-              fileNamesArray: multiFilesObject.fileNamesArray,
-              link: infoObject.body.link,
-              filesArray: multiFilesObject.filesArray,
-              oversize: infoObject.body.oversize!,
-              spoiler: false,
-            })
-            .then(
-              (): Response => infoObject.c.body(null, { status: noContent }),
-            )
-            .catch(
-              (): Response => infoObject.c.body(null, { status: serverError }),
-            );
-        } catch (e: unknown) {
-          return await SendMessages.errorMessage({
-            token: infoObject.body.token,
-            channel: infoObject.body.channel,
-            message: infoObject.body.message,
-            number: infoObject.body.number,
-            link: infoObject.body.link,
-            description: (e as Error).message,
-            startTime: infoObject.body.startTime,
-            oversize: infoObject.body.oversize!,
-          })
-            .then(
-              (): Response => infoObject.c.body(null, { status: noContent }),
-            )
-            .catch(
-              (): Response => infoObject.c.body(null, { status: serverError }),
-            );
-        } finally {
-          infoObject.body = null;
-          multiFilesObject = null;
-        }
-      },
+      ): Promise<Response> => handleMultiSuccess(infoObject, false, false),
     },
     dlSpoiler: {
       /**
@@ -136,118 +162,41 @@ const callbackSuccessFunctions: CallbackTypes.Functions.callbackSuccess = {
        * @param {InfoObject<T>} infoObject - The information object containing the necessary data for the callback success event.
        * @return {Promise<Response>} A promise that resolves to a Response object.
        */
-      single: async <T extends string>(
+      single: <T extends string>(
         infoObject: InfoObject<T>,
-      ): Promise<Response> => {
-        if (!infoObject.body)
-          return infoObject.c.body(null, { status: serverError });
-        let filesObject = await Contents.singleFileContent(infoObject.body)
-          .then((i) => i)
-          .catch(() => null);
-        try {
-          if (!filesObject)
-            return infoObject.c.body(null, { status: serverError });
-          return await SendMessages.successMessage
-            .singleFile({
-              token: infoObject.body.token,
-              channelId: infoObject.body.channel,
-              messageId: infoObject.body.message,
-              runNumber: infoObject.body.number,
-              startTime: infoObject.body.startTime,
-              totalSize: infoObject.body.size!,
-              fileName: filesObject.fileName,
-              link: infoObject.body.link,
-              file: filesObject.blobData,
-              oversize: infoObject.body.oversize!,
-              spoiler: true,
-            })
-            .then(
-              (): Response => infoObject.c.body(null, { status: noContent }),
-            )
-            .catch(
-              (): Response => infoObject.c.body(null, { status: serverError }),
-            );
-        } catch (e: unknown) {
-          return await SendMessages.errorMessage({
-            token: infoObject.body.token,
-            channel: infoObject.body.channel,
-            message: infoObject.body.message,
-            number: infoObject.body.number,
-            link: infoObject.body.link,
-            description: (e as Error).message,
-            startTime: infoObject.body.startTime,
-            oversize: infoObject.body.oversize!,
-          })
-            .then(
-              (): Response => infoObject.c.body(null, { status: noContent }),
-            )
-            .catch(
-              (): Response => infoObject.c.body(null, { status: serverError }),
-            );
-        } finally {
-          infoObject.body = null;
-          filesObject = null;
-        }
-      },
+      ): Promise<Response> => handleSingleSuccess(infoObject, true, false),
       /**
        * Asynchronously handles multiple callback success events with a spoiler.
        *
        * @param {InfoObject<T>} infoObject - The information object containing the necessary data for the callback success event.
        * @return {Promise<Response>} A promise that resolves to a Response object.
        */
-      multi: async <T extends string>(
+      multi: <T extends string>(
         infoObject: InfoObject<T>,
-      ): Promise<Response> => {
-        if (!infoObject.body)
-          return infoObject.c.body(null, { status: serverError });
-        let multiFilesObject = await Contents.multiFilesContent(infoObject.body)
-          .then((i) => i)
-          .catch(() => null);
-        try {
-          if (!multiFilesObject)
-            return infoObject.c.body(null, { status: serverError });
-          return await SendMessages.successMessage
-            .multiFiles({
-              token: infoObject.body.token,
-              channelId: infoObject.body.channel,
-              messageId: infoObject.body.message,
-              runNumber: infoObject.body.number,
-              startTime: infoObject.body.startTime,
-              totalSize: infoObject.body.size!,
-              fileNamesArray: multiFilesObject.fileNamesArray,
-              link: infoObject.body.link,
-              filesArray: multiFilesObject.filesArray,
-              oversize: infoObject.body.oversize!,
-              spoiler: true,
-            })
-            .then(
-              (): Response => infoObject.c.body(null, { status: noContent }),
-            )
-            .catch(
-              (): Response => infoObject.c.body(null, { status: serverError }),
-            );
-        } catch (e: unknown) {
-          return await SendMessages.errorMessage({
-            token: infoObject.body.token,
-            channel: infoObject.body.channel,
-            message: infoObject.body.message,
-            number: infoObject.body.number,
-            link: infoObject.body.link,
-            description: (e as Error).message,
-            startTime: infoObject.body.startTime,
-            oversize: infoObject.body.oversize!,
-          })
-            .then(
-              (): Response => infoObject.c.body(null, { status: noContent }),
-            )
-            .catch(
-              (): Response => infoObject.c.body(null, { status: serverError }),
-            );
-        } finally {
-          infoObject.body = null;
-          multiFilesObject = null;
-        }
-      },
+      ): Promise<Response> => handleMultiSuccess(infoObject, true, false),
+    },
+    threadDl: {
+      /**
+       * Asynchronously handles a single callback success event for a thread
+       * download. Uses `editMessage` instead of `editFollowupMessage` so the
+       * resolved message lands inside the thread channel.
+       *
+       * @param {InfoObject<T>} infoObject - The information object containing the necessary data for the callback success event.
+       * @return {Promise<Response>} A promise that resolves to a Response object.
+       */
+      single: <T extends string>(
+        infoObject: InfoObject<T>,
+      ): Promise<Response> => handleSingleSuccess(infoObject, false, true),
+      /**
+       * Asynchronously handles multi callback success events for a thread
+       * download. Uses `editMessage` instead of `editFollowupMessage`.
+       *
+       * @param {InfoObject<T>} infoObject - The information object containing the necessary data for the callback success event.
+       * @return {Promise<Response>} A promise that resolves to a Response object.
+       */
+      multi: <T extends string>(
+        infoObject: InfoObject<T>,
+      ): Promise<Response> => handleMultiSuccess(infoObject, false, true),
     },
   },
 };

--- a/src/router/messages/errorMessage.ts
+++ b/src/router/messages/errorMessage.ts
@@ -21,7 +21,11 @@ const errorMessage = (
   const runTime: number =
     new Date().getTime() - Number(errorMessageObject!.startTime);
   const useThread: boolean = !!errorMessageObject!.useThread;
+  // editMessage (thread mode) is not bound by the 15-min interaction-token
+  // window or the followup oversize fallback, so always edit the placeholder
+  // when running in a thread.
   const isEditOriginalMessage: boolean =
+    useThread ||
     runTime <= editFollowupMessageTimeLimit ||
     errorMessageObject!.oversize !== trueOversize;
   return Match(isEditOriginalMessage)

--- a/src/router/messages/errorMessage.ts
+++ b/src/router/messages/errorMessage.ts
@@ -1,6 +1,6 @@
 import bot from "@bot/bot.ts";
 import { Match } from "functional";
-import { Message } from "discordeno";
+import { Message, EditMessage } from "discordeno";
 import { Messages, Constants } from "@libs";
 import { CreateMessageTypes } from "@router/types/createMessageTypes.ts";
 
@@ -16,28 +16,41 @@ const editFollowupMessageTimeLimit = Constants.EDIT_FOLLOWUP_MESSAGE_TIME_LIMIT;
  * @return {Promise<Message>} A promise that resolves to a message response.
  */
 const errorMessage = (
-  errorMessageObject: SendErrorMessageObject
+  errorMessageObject: SendErrorMessageObject,
 ): Promise<Message> => {
   const runTime: number =
     new Date().getTime() - Number(errorMessageObject!.startTime);
-  const isEditFollowupMessage: boolean =
+  const useThread: boolean = !!errorMessageObject!.useThread;
+  const isEditOriginalMessage: boolean =
     runTime <= editFollowupMessageTimeLimit ||
     errorMessageObject!.oversize !== trueOversize;
-  return Match(isEditFollowupMessage)
+  return Match(isEditOriginalMessage)
     .with(
       true,
       async (): Promise<Message> =>
-        await bot.helpers
-          .editFollowupMessage(
-            errorMessageObject!.token,
-            errorMessageObject!.message,
-            Messages.createErrorMessage({
-              runNumber: errorMessageObject!.number,
-              description: errorMessageObject!.description,
-              link: errorMessageObject!.link,
-            })
-          )
-          .finally((): null => (errorMessageObject = null))
+        useThread
+          ? await bot.helpers
+              .editMessage(
+                errorMessageObject!.channel,
+                errorMessageObject!.message,
+                Messages.createErrorMessage({
+                  runNumber: errorMessageObject!.number,
+                  description: errorMessageObject!.description,
+                  link: errorMessageObject!.link,
+                }) as EditMessage,
+              )
+              .finally((): null => (errorMessageObject = null))
+          : await bot.helpers
+              .editFollowupMessage(
+                errorMessageObject!.token,
+                errorMessageObject!.message,
+                Messages.createErrorMessage({
+                  runNumber: errorMessageObject!.number,
+                  description: errorMessageObject!.description,
+                  link: errorMessageObject!.link,
+                }),
+              )
+              .finally((): null => (errorMessageObject = null)),
     )
     .with(
       false,
@@ -51,9 +64,9 @@ const errorMessage = (
               runNumber: errorMessageObject!.number,
               description: errorMessageObject!.description,
               link: errorMessageObject!.link,
-            })
+            }),
           )
-          .finally((): null => (errorMessageObject = null))
+          .finally((): null => (errorMessageObject = null)),
     )
     .exhaustive();
 };

--- a/src/router/messages/successMessage.ts
+++ b/src/router/messages/successMessage.ts
@@ -25,7 +25,11 @@ const successMessage = {
     const runTime: number =
       new Date().getTime() - Number(singleSuccsessMessageObject!.startTime);
     const useThread: boolean = !!singleSuccsessMessageObject!.useThread;
+    // editMessage (thread mode) is not bound by the 15-min interaction-token
+    // window or the followup oversize fallback, so always edit the
+    // placeholder when running in a thread.
     const isEditOriginalMessage: boolean =
+      useThread ||
       runTime <= editFollowupMessageTimeLimit ||
       singleSuccsessMessageObject!.oversize !== trueOversize;
     return Match(isEditOriginalMessage)
@@ -98,7 +102,11 @@ const successMessage = {
     const runTime: number =
       new Date().getTime() - Number(multiSuccsessMessageObject!.startTime);
     const useThread: boolean = !!multiSuccsessMessageObject!.useThread;
+    // editMessage (thread mode) is not bound by the 15-min interaction-token
+    // window or the followup oversize fallback, so always edit the
+    // placeholder when running in a thread.
     const editOriginalMessageFlag: boolean =
+      useThread ||
       runTime <= editFollowupMessageTimeLimit ||
       multiSuccsessMessageObject!.oversize !== trueOversize;
     return Match(editOriginalMessageFlag)

--- a/src/router/messages/successMessage.ts
+++ b/src/router/messages/successMessage.ts
@@ -1,6 +1,6 @@
 import bot from "@bot/bot.ts";
 import { Match } from "functional";
-import { Message } from "discordeno";
+import { Message, EditMessage } from "discordeno";
 import { Messages, Constants } from "@libs";
 import { CreateMessageTypes } from "@router/types/createMessageTypes.ts";
 
@@ -24,28 +24,45 @@ const successMessage = {
   ): Promise<Message> => {
     const runTime: number =
       new Date().getTime() - Number(singleSuccsessMessageObject!.startTime);
-    const isEditFollowupMessage: boolean =
+    const useThread: boolean = !!singleSuccsessMessageObject!.useThread;
+    const isEditOriginalMessage: boolean =
       runTime <= editFollowupMessageTimeLimit ||
       singleSuccsessMessageObject!.oversize !== trueOversize;
-    return Match(isEditFollowupMessage)
+    return Match(isEditOriginalMessage)
       .with(
         true,
         async (): Promise<Message> =>
-          await bot.helpers
-            .editFollowupMessage(
-              singleSuccsessMessageObject!.token,
-              singleSuccsessMessageObject!.messageId,
-              Messages.createSuccessMessage({
-                runNumber: singleSuccsessMessageObject!.runNumber,
-                runTime: runTime,
-                totalSize: singleSuccsessMessageObject!.totalSize,
-                fileName: singleSuccsessMessageObject!.fileName,
-                link: singleSuccsessMessageObject!.link,
-                file: singleSuccsessMessageObject!.file,
-                spoiler: singleSuccsessMessageObject!.spoiler,
-              }),
-            )
-            .finally((): null => (singleSuccsessMessageObject = null)),
+          useThread
+            ? await bot.helpers
+                .editMessage(
+                  singleSuccsessMessageObject!.channelId,
+                  singleSuccsessMessageObject!.messageId,
+                  Messages.createSuccessMessage({
+                    runNumber: singleSuccsessMessageObject!.runNumber,
+                    runTime: runTime,
+                    totalSize: singleSuccsessMessageObject!.totalSize,
+                    fileName: singleSuccsessMessageObject!.fileName,
+                    link: singleSuccsessMessageObject!.link,
+                    file: singleSuccsessMessageObject!.file,
+                    spoiler: singleSuccsessMessageObject!.spoiler,
+                  }) as EditMessage,
+                )
+                .finally((): null => (singleSuccsessMessageObject = null))
+            : await bot.helpers
+                .editFollowupMessage(
+                  singleSuccsessMessageObject!.token,
+                  singleSuccsessMessageObject!.messageId,
+                  Messages.createSuccessMessage({
+                    runNumber: singleSuccsessMessageObject!.runNumber,
+                    runTime: runTime,
+                    totalSize: singleSuccsessMessageObject!.totalSize,
+                    fileName: singleSuccsessMessageObject!.fileName,
+                    link: singleSuccsessMessageObject!.link,
+                    file: singleSuccsessMessageObject!.file,
+                    spoiler: singleSuccsessMessageObject!.spoiler,
+                  }),
+                )
+                .finally((): null => (singleSuccsessMessageObject = null)),
       )
       .with(
         false,
@@ -80,28 +97,45 @@ const successMessage = {
   ): Promise<Message> => {
     const runTime: number =
       new Date().getTime() - Number(multiSuccsessMessageObject!.startTime);
-    const editFollowupMessageFlag: boolean =
+    const useThread: boolean = !!multiSuccsessMessageObject!.useThread;
+    const editOriginalMessageFlag: boolean =
       runTime <= editFollowupMessageTimeLimit ||
       multiSuccsessMessageObject!.oversize !== trueOversize;
-    return Match(editFollowupMessageFlag)
+    return Match(editOriginalMessageFlag)
       .with(
         true,
         async (): Promise<Message> =>
-          await bot.helpers
-            .editFollowupMessage(
-              multiSuccsessMessageObject!.token,
-              multiSuccsessMessageObject!.messageId,
-              Messages.createSuccessMessage({
-                runNumber: multiSuccsessMessageObject!.runNumber,
-                runTime: runTime,
-                totalSize: multiSuccsessMessageObject!.totalSize,
-                fileNamesArray: multiSuccsessMessageObject!.fileNamesArray,
-                link: multiSuccsessMessageObject!.link,
-                filesArray: multiSuccsessMessageObject!.filesArray,
-                spoiler: multiSuccsessMessageObject!.spoiler,
-              }),
-            )
-            .finally((): null => (multiSuccsessMessageObject = null)),
+          useThread
+            ? await bot.helpers
+                .editMessage(
+                  multiSuccsessMessageObject!.channelId,
+                  multiSuccsessMessageObject!.messageId,
+                  Messages.createSuccessMessage({
+                    runNumber: multiSuccsessMessageObject!.runNumber,
+                    runTime: runTime,
+                    totalSize: multiSuccsessMessageObject!.totalSize,
+                    fileNamesArray: multiSuccsessMessageObject!.fileNamesArray,
+                    link: multiSuccsessMessageObject!.link,
+                    filesArray: multiSuccsessMessageObject!.filesArray,
+                    spoiler: multiSuccsessMessageObject!.spoiler,
+                  }) as EditMessage,
+                )
+                .finally((): null => (multiSuccsessMessageObject = null))
+            : await bot.helpers
+                .editFollowupMessage(
+                  multiSuccsessMessageObject!.token,
+                  multiSuccsessMessageObject!.messageId,
+                  Messages.createSuccessMessage({
+                    runNumber: multiSuccsessMessageObject!.runNumber,
+                    runTime: runTime,
+                    totalSize: multiSuccsessMessageObject!.totalSize,
+                    fileNamesArray: multiSuccsessMessageObject!.fileNamesArray,
+                    link: multiSuccsessMessageObject!.link,
+                    filesArray: multiSuccsessMessageObject!.filesArray,
+                    spoiler: multiSuccsessMessageObject!.spoiler,
+                  }),
+                )
+                .finally((): null => (multiSuccsessMessageObject = null)),
       )
       .with(
         false,

--- a/src/router/types/callbackTypes.ts
+++ b/src/router/types/callbackTypes.ts
@@ -5,8 +5,8 @@ export namespace CallbackTypes {
   export type bodyDataObject = {
     status: "success" | "failure" | "progress" | null;
     number: string;
-    commandType?: "dl" | "dl-spoiler";
-    actionType?: "single" | "multi";
+    commandType?: "dl" | "dl-spoiler" | "threaddl";
+    actionType?: "single" | "multi" | "thread-single" | "thread-multi";
     startTime: string;
     channel: string;
     message: string;

--- a/src/router/types/createMessageTypes.ts
+++ b/src/router/types/createMessageTypes.ts
@@ -50,6 +50,7 @@ export namespace CreateMessageTypes {
       file: Blob;
       oversize: string;
       spoiler: boolean;
+      useThread?: boolean;
     };
     export type multiFilesObject = {
       token: string;
@@ -63,6 +64,7 @@ export namespace CreateMessageTypes {
       filesArray: FileContent[];
       oversize: string;
       spoiler: boolean;
+      useThread?: boolean;
     };
   }
   export type sendErrorMessageObject = {
@@ -74,5 +76,6 @@ export namespace CreateMessageTypes {
     description: string;
     startTime: string;
     oversize: string;
+    useThread?: boolean;
   };
 }


### PR DESCRIPTION
## Summary

- Adds a new `/threaddl name:<thread name> url:<URL1 URL2 ...>` slash command that creates a Discord thread and downloads every URL into it
- Wires a new `repository_dispatch` (`event_type=thread-download`) and a dedicated workflow `.github/workflows/run-thread.yml` that uses a **dynamic GitHub Actions matrix** (one matrix shard per URL) for true parallel processing
- Existing `/dl` and `/dl-spoiler` paths are untouched; `run.yml` is unchanged

## アーキテクチャ図

```mermaid
sequenceDiagram
  actor U as User (Discord)
  participant B as Bot (Deno + Hono)
  participant GH as GitHub Actions
  participant DC as Discord (Thread)

  U->>B: /threaddl name:Foo url:"u1 u2 u3"
  B-->>U: Defer (DeferredChannelMessageWithSource)
  B->>DC: startThreadWithoutMessage(channel, {name})
  DC-->>B: Thread channel ID
  B->>DC: sendMessage(thread, "Queuing...") × N
  DC-->>B: N message IDs
  B->>GH: repository_dispatch (thread-download)<br/>{ channel, token, links: [{link, message}, ...] }
  GH->>GH: prepare job → emit strategy.matrix from links
  par 並列実行 (max-parallel: 16)
    GH->>GH: download[shard 1] (yt-dlp + ffmpeg)
    GH->>GH: download[shard 2] ...
    GH->>GH: download[shard N] ...
  end
  GH-->>B: callback (per shard) status=success/failure/progress<br/>commandType=threaddl, channel=thread, message=queue msg id
  B->>DC: editMessage(thread, message, result)
```

## 実装内容

### Bot 側
- `src/bot/bot.ts`
  - `threadDlCommand` をグローバル登録
  - `commandType=threaddl` の場合は新ハンドラ `threadInteractionCreate` にディスパッチ
- 新規 `src/bot/threadInteractionCreate.ts`
  - `name` / `url` オプションを抽出 → URL を半角スペース分割
  - `bot.helpers.startThreadWithoutMessage(channelId, { name, autoArchiveDuration: 1440, type: PublicThread })` でスレッド作成
  - スレッド内に「🕑Queuing...」メッセージを N 件送信（`sendMessage`）
  - 1 回の `webhookThread` で `links` 配列を含む `repository_dispatch` を発火
- `src/libs/webhook.ts` に `webhookThread` を追加（既存 `webhook` には手を入れていない）
- `src/libs/constants.ts` に `Webhook.Json.EVENT_TYPE_THREAD`, `Thread.AUTO_ARCHIVE_DURATION/TYPE`, `CallbackObject.commandType.THREAD_DL`, `CallbackObject.actionType.THREAD_SINGLE/THREAD_MULTI` を追加

### Callback 側
- `successMessage` / `errorMessage` / `callbackProgressFunctions` / `callbackFailureFunctions` に `useThread` 分岐を追加
  - `useThread=true`: `bot.helpers.editMessage(channel, message, ...)` を使用（thread 内のメッセージを直接編集）
  - `useThread=false`: 従来通り `bot.helpers.editFollowupMessage(token, message, ...)` を使用
- `useThread` は `body.commandType === "threaddl"` で判定（progress/failure）か、明示的に `actionType=thread-single|thread-multi` を見て判定（success）
- `callbackSuccessFunctions` に `success.threadDl.{single,multi}` を追加。`dl` / `dlSpoiler` / `threadDl` で重複していたコードを共通の `handleSingleSuccess` / `handleMultiSuccess` にまとめた
- `Custom.CallbackPattern` に `Success.ThreadDl.{Single,Multi}`, `ProgressThread`, `FailureThread` を追加。`callback.ts` の `Match` で `Progress`/`Failure` のジェネリックパターンより**前**にスレッド専用パターンをチェック

### GitHub Actions 側
- 新規 `.github/workflows/run-thread.yml`
  - `repository_dispatch` types: `thread-download`
  - `prepare` ジョブ: `jq` で `client_payload.links[]` から `{include: [{link, message}, ...]}` を生成し outputs に渡す
  - `run-with-container` ジョブ: `needs: [prepare]` + `strategy.matrix: ${{ fromJson(needs.prepare.outputs.matrix) }}` で並列実行（`max-parallel: 16`, `fail-fast: false`）
  - 各 shard は既存 `run.yml` と同じ docker runner image `ghcr.io/<owner>/tw-dl-runner:latest` を使い、yt-dlp / ffmpeg のロジックは互換
  - shard 個別の値は `${{ matrix.link }}` / `${{ matrix.message }}` で展開。**シェル展開時は `toJSON(matrix.X)` か env 変数経由**にしてユーザー入力 URL のシェル injection を回避
  - 既存 `run.yml` は無変更

## 既存への影響
- `/dl`, `/dl-spoiler` のコードパス（`interactionCreate.ts`, `webhook()`, `callback*` の generic Progress/Failure パターン）は意味的に変更なし
- `successMessage` / `errorMessage` 等は `useThread` がオプショナルで未指定時は従来挙動

## テスト方法
- 型チェック: `deno check --import-map import_map.json --allow-import=deno.land:443,jsr.io:443,cdn.skypack.dev:443,esm.sh:443,unpkg.com:443 src/main.ts` → エラーなし
- Lint: `deno lint` → 既存の `tools/textlint.ts` 由来 8 エラーのみ（master と同じ。本 PR で増えていない）
- 実機での疎通テストはまだ未実施。PR レビュー後にステージング Bot で `/threaddl` を叩いて以下を確認したい

## 動作確認チェックリスト

- [ ] `/threaddl name:test url:<single URL>` で thread が作成され、URL がスレッド内で処理される
- [ ] `/threaddl name:test url:<URL1 URL2 URL3>` で 3 並列で download ジョブが走る (Actions 上で確認)
- [ ] 各 shard の progress/success/failure が **スレッド内のキューメッセージ** に正しく反映される
- [ ] 不正 URL を含めた場合に `createErrorMessage` で followup エラーが返る
- [ ] `/dl` と `/dl-spoiler` が **回帰せず**従来通り動作する
- [ ] 17+ URL 投入時に matrix が `max-parallel: 16` で頭打ちになる（残りはキューに積まれる）