### PR TITLE
feat: Modal-based URL input + /threaddl-spoiler

### DIFF
--- a/src/bot/bot.ts
+++ b/src/bot/bot.ts
@@ -1,9 +1,16 @@
 import { Commands } from "@bot/commands.ts";
 import { Secrets } from "@libs";
 import { Match } from "functional";
-import { Bot, createBot, Intents, Interaction } from "discordeno";
+import {
+  Bot,
+  createBot,
+  Intents,
+  Interaction,
+  InteractionTypes,
+} from "discordeno";
 import { interactionCreate } from "@bot/interactionCreate.ts";
 import { threadInteractionCreate } from "@bot/threadInteractionCreate.ts";
+import { threadModalSubmit } from "@bot/threadModalSubmit.ts";
 
 const bot: Bot = createBot({
   token: Secrets.DISCORD_TOKEN,
@@ -15,14 +22,23 @@ const bot: Bot = createBot({
   },
 });
 
-// NOTE: slash command registration (including `threadDlCommand`) was
-// moved to `registerCommands` (see `src/bot/registerCommands.ts`) and
-// is now invoked from `src/main.ts` before `startBot`. Keeping it out
-// of `bot.ts`'s top-level lets unit tests import the bot setup without
-// making a Discord REST call at module load time.
+// NOTE: slash command registration (including `threadDlCommand` and
+// `threadDlSpoilerCommand`) was moved to `registerCommands` (see
+// `src/bot/registerCommands.ts`) and is now invoked from `src/main.ts`
+// before `startBot`. Keeping it out of `bot.ts`'s top-level lets unit
+// tests import the bot setup without making a Discord REST call at module
+// load time.
 
 /**
  * Handles the interactionCreate event for the bot.
+ *
+ * Dispatches based on `interaction.type`:
+ * - `ApplicationCommand`: route by command name to the matching handler
+ *   (`/dl` and `/dl-spoiler` go to `interactionCreate`, `/threaddl` and
+ *   `/threaddl-spoiler` go to `threadInteractionCreate` which opens a
+ *   Modal so the user can paste many URLs).
+ * - `ModalSubmit`: hand off to `threadModalSubmit`, which validates the
+ *   customId prefix, extracts URLs, and runs the shared `runThreadFlow`.
  *
  * @param {Bot} b - The bot instance.
  * @param {Interaction} interaction - The interaction object.
@@ -33,6 +49,14 @@ bot.events.interactionCreate = async (
   interaction: Interaction,
 ): Promise<void> => {
   if (!interaction.data) return;
+
+  if (interaction.type === InteractionTypes.ModalSubmit) {
+    await threadModalSubmit({ b, data: interaction.data, interaction });
+    return;
+  }
+
+  if (interaction.type !== InteractionTypes.ApplicationCommand) return;
+
   const props = {
     b,
     data: interaction.data,
@@ -56,6 +80,13 @@ bot.events.interactionCreate = async (
     )
     .with(
       Commands.threadDlCommand.name,
+      async (commandType: string): Promise<void> => {
+        props.commandType = commandType;
+        await threadInteractionCreate(props);
+      },
+    )
+    .with(
+      Commands.threadDlSpoilerCommand.name,
       async (commandType: string): Promise<void> => {
         props.commandType = commandType;
         await threadInteractionCreate(props);

--- a/src/bot/commands.ts
+++ b/src/bot/commands.ts
@@ -5,6 +5,7 @@ type CommandsType = {
   dlCommand: CreateSlashApplicationCommand;
   dlSpoilerCommand: CreateSlashApplicationCommand;
   threadDlCommand: CreateSlashApplicationCommand;
+  threadDlSpoilerCommand: CreateSlashApplicationCommand;
 };
 
 export const Commands: CommandsType = {
@@ -34,6 +35,12 @@ export const Commands: CommandsType = {
       },
     ],
   },
+  // NOTE: `/threaddl` and `/threaddl-spoiler` are Modal-based commands.
+  // The `url` option used to live here, but URLs are now collected from a
+  // Discord Modal (Paragraph TextInput, one URL per line) so users can paste
+  // many URLs without worrying about quoting/escaping.
+  // The slash command itself only takes `name` (the thread title), and the
+  // bot opens the Modal as the immediate interaction response.
   threadDlCommand: {
     name: Constants.Webhook.Json.ClientPayload.CommandType.THREAD_DOWNLOAD,
     description: "DL multiple Tweets into a thread",
@@ -45,7 +52,20 @@ export const Commands: CommandsType = {
         required: true,
         description: "Thread Name",
       },
-      { name: "url", type: 3, required: true, description: "Tweet URL" },
+    ],
+  },
+  threadDlSpoilerCommand: {
+    name:
+      Constants.Webhook.Json.ClientPayload.CommandType.THREAD_DOWNLOAD_SPOILER,
+    description: "DL multiple Tweets into a thread with spoiler",
+    type: 1,
+    options: [
+      {
+        name: "name",
+        type: 3,
+        required: true,
+        description: "Thread Name",
+      },
     ],
   },
 };

--- a/src/bot/registerCommands.ts
+++ b/src/bot/registerCommands.ts
@@ -22,4 +22,7 @@ export const registerCommands = async (bot: Bot): Promise<void> => {
   await bot.helpers.createGlobalApplicationCommand(Commands.dlCommand);
   await bot.helpers.createGlobalApplicationCommand(Commands.dlSpoilerCommand);
   await bot.helpers.createGlobalApplicationCommand(Commands.threadDlCommand);
+  await bot.helpers.createGlobalApplicationCommand(
+    Commands.threadDlSpoilerCommand,
+  );
 };

--- a/src/bot/runThreadFlow.ts
+++ b/src/bot/runThreadFlow.ts
@@ -1,0 +1,162 @@
+import { If } from "functional";
+import { KyResponse } from "ky";
+import {
+  Bot,
+  ChannelTypes,
+  EditMessage,
+  Interaction,
+  InteractionResponseTypes,
+  Message,
+} from "discordeno";
+import { Messages, Constants, isUrl, webhookThread } from "@libs";
+
+/**
+ * Pure "do the thread thing" flow shared by:
+ * - the legacy `/threaddl` ApplicationCommand path (kept for reference; the
+ *   live entry point is now Modal-based, see `threadInteractionCreate.ts`)
+ * - the new ModalSubmit path that fires after the user pastes URLs into the
+ *   Discord Modal (see `threadModalSubmit.ts`)
+ *
+ * Inputs:
+ * - `interaction`: the interaction whose token we use for the followup
+ *   (Defer + followup message). For Modal flows this is the **ModalSubmit
+ *   interaction**, not the original ApplicationCommand.
+ * - `commandType`: `"threaddl"` or `"threaddl-spoiler"` — forwarded into the
+ *   `repository_dispatch` payload so the bot's callback router can route
+ *   spoiler vs. non-spoiler accordingly.
+ * - `threadName`: title for the thread that gets created.
+ * - `contents`: the pre-extracted list of URL strings (already validated by
+ *   the caller — no further parsing is done here).
+ *
+ * Side effects:
+ * 1. ACK the interaction (DeferredChannelMessageWithSource).
+ * 2. If validation fails (no URLs, invalid URL, missing thread context),
+ *    post an error followup and return.
+ * 3. Otherwise create a Discord thread, post one "Queuing" message per URL
+ *    inside the thread, and fire a single `repository_dispatch` (event_type
+ *    = `thread-download`) with the `links` array so the GitHub Actions
+ *    matrix workflow can fan-out per-URL processing in parallel.
+ *
+ * @param props - Flow inputs.
+ * @returns A promise that resolves when the fan-out is dispatched.
+ */
+export const runThreadFlow = async (props: {
+  b: Bot;
+  interaction: Interaction;
+  commandType: string;
+  threadName: string;
+  contents: string[];
+}): Promise<void> => {
+  await props.b.helpers.sendInteractionResponse(
+    props.interaction.id,
+    props.interaction.token,
+    {
+      type: InteractionResponseTypes.DeferredChannelMessageWithSource,
+    },
+  );
+
+  const allValid: boolean =
+    props.contents.length > 0 &&
+    props.contents.every((i: string): boolean => isUrl(i)) &&
+    props.threadName.length > 0;
+
+  await If(
+    !allValid,
+    async (): Promise<void> => {
+      await props.b.helpers.sendFollowupMessage(props.interaction.token, {
+        type: InteractionResponseTypes.ChannelMessageWithSource,
+        data: Messages.createErrorMessage({
+          description:
+            props.contents.length > 0
+              ? props.contents.join("\n")
+              : "No valid URL was found in the input.",
+        }),
+      });
+    },
+  ).else(async (): Promise<void> => {
+    // Threads can only be created inside a guild text/announcement/forum
+    // channel. `interaction.channelId` is populated for DM interactions too
+    // (it's the DM channel ID), so also gate on `guildId` to ensure we are
+    // running in a guild context before calling `startThreadWithoutMessage`.
+    if (!props.interaction.channelId || !props.interaction.guildId) {
+      await props.b.helpers.sendFollowupMessage(props.interaction.token, {
+        type: InteractionResponseTypes.ChannelMessageWithSource,
+        data: Messages.createErrorMessage({
+          description: "This command must be used in a guild text channel.",
+        }),
+      });
+      return;
+    }
+
+    const thread = await props.b.helpers
+      .startThreadWithoutMessage(props.interaction.channelId, {
+        name: props.threadName,
+        autoArchiveDuration: Constants.Thread.AUTO_ARCHIVE_DURATION,
+        type: Constants.Thread.TYPE as ChannelTypes.PublicThread,
+      })
+      .catch(async (e: Error): Promise<null> => {
+        await props.b.helpers.sendFollowupMessage(props.interaction.token, {
+          type: InteractionResponseTypes.ChannelMessageWithSource,
+          data: Messages.createErrorMessage({
+            description: `Failed to create thread: ${e.message}`,
+          }),
+        });
+        return null;
+      });
+    if (!thread) return;
+
+    await props.b.helpers.sendFollowupMessage(props.interaction.token, {
+      type: InteractionResponseTypes.ChannelMessageWithSource,
+      data: {
+        content: `🧵 Created thread <#${thread.id}> for ${props.contents.length} URL(s).`,
+      },
+    });
+
+    const queueResults = await Promise.all(
+      props.contents.map(
+        async (
+          content: string,
+        ): Promise<{ link: string; message: string } | null> =>
+          await props.b.helpers
+            .sendMessage(
+              thread.id,
+              Messages.createProgressMessage({
+                content: `**🕑Queuing...**`,
+                link: content,
+              }),
+            )
+            .then((m: Message): { link: string; message: string } => ({
+              link: content,
+              message: `${m.id}`,
+            }))
+            .catch((): null => null),
+      ),
+    );
+    const links = queueResults.filter(
+      (i): i is { link: string; message: string } => i !== null,
+    );
+    if (links.length === 0) return;
+
+    await webhookThread({
+      commandType: props.commandType,
+      links,
+      channelId: thread.id,
+      token: props.interaction.token,
+      startTime: new Date().getTime().toString(),
+    }).catch(async (e: Error): Promise<KyResponse | void> => {
+      await Promise.all(
+        links.map(
+          async (i: { link: string; message: string }): Promise<Message> =>
+            await props.b.helpers.editMessage(
+              thread.id,
+              BigInt(i.message),
+              Messages.createErrorMessage({
+                link: i.link,
+                description: e.message,
+              }) as EditMessage,
+            ),
+        ),
+      );
+    });
+  });
+};

--- a/src/bot/threadInteractionCreate.ts
+++ b/src/bot/threadInteractionCreate.ts
@@ -1,14 +1,10 @@
-import { If } from "functional";
-import { KyResponse } from "ky";
 import {
   Bot,
-  ChannelTypes,
-  EditMessage,
   Interaction,
   InteractionResponseTypes,
-  Message,
+  MessageComponentTypes,
+  TextStyles,
 } from "discordeno";
-import { Messages, Constants, isUrl, webhookThread } from "@libs";
 
 type InteractionData = Exclude<Pick<Interaction, "data">["data"], undefined>;
 type InteractionOption = Exclude<
@@ -17,7 +13,26 @@ type InteractionOption = Exclude<
 >[number];
 
 const NAME_OPTION = "name";
-const URL_OPTION = "url";
+
+/**
+ * customId conventions used by the thread Modal flow.
+ *
+ * The wire format is:
+ *
+ *     <commandType>|<threadName-truncated-to-MAX_NAME_IN_CUSTOM_ID>
+ *
+ * Discord caps `customId` at 100 characters. Today the longest commandType
+ * is `"threaddl-spoiler"` (16 chars) plus the `|` separator (1 char), so we
+ * leave 80 chars of room for the thread name to be safe across both
+ * `/threaddl` and `/threaddl-spoiler`.
+ *
+ * Truncation here only affects what we round-trip via `customId`. The Modal
+ * `title` (and the actual thread name we hand to `startThreadWithoutMessage`)
+ * use the same truncated value so what the user sees, what gets created on
+ * Discord, and what we route on the callback are all consistent.
+ */
+export const MAX_NAME_IN_CUSTOM_ID = 80;
+export const URLS_INPUT_CUSTOM_ID = "urls";
 
 /**
  * Resolves a string-typed option from the interaction data by name.
@@ -30,22 +45,29 @@ const pickOption = (
   options: InteractionOption[] | undefined,
   name: string,
 ): string =>
-  (options ?? []).find(
+  ((options ?? []).find(
     (i: InteractionOption): boolean => i.name === name,
-  )?.value as string ?? "";
+  )?.value as string) ?? "";
 
 /**
- * Handles the `/threaddl` interaction by creating a Discord thread on the
- * source channel, queueing one message per URL inside the thread, and firing
- * a single `repository_dispatch` (event_type=`thread-download`) so the
- * GitHub Actions matrix workflow can fan-out per-URL processing in parallel.
+ * Handles the `/threaddl` and `/threaddl-spoiler` ApplicationCommand
+ * interactions by opening a Discord Modal so the user can paste an
+ * arbitrary number of URLs (one per line) without quoting/escaping.
  *
- * @param {object} props - The handler props bag.
- * @param {Bot} props.b - The bot instance.
- * @param {InteractionData} props.data - The interaction data object.
- * @param {Interaction} props.interaction - The interaction object.
- * @param {string} props.commandType - The command type (`threaddl`).
- * @return {Promise<void>} A promise that resolves when fan-out completes.
+ * The actual thread-creation + dispatch flow does NOT run here — it runs on
+ * the follow-up `ModalSubmit` interaction (see `threadModalSubmit.ts`).
+ *
+ * Why this is split: a Modal must be the *first* response to an interaction.
+ * `DeferredChannelMessageWithSource` would consume the response slot and
+ * make the Modal impossible. So this handler returns the Modal immediately,
+ * and the ModalSubmit handler is the one that ACKs + does the work.
+ *
+ * @param props - The handler props bag.
+ * @param props.b - The bot instance.
+ * @param props.data - The interaction data object.
+ * @param props.interaction - The interaction object.
+ * @param props.commandType - The command type (`threaddl` or `threaddl-spoiler`).
+ * @returns A promise that resolves when the Modal response has been sent.
  */
 export const threadInteractionCreate = async (props: {
   b: Bot;
@@ -53,119 +75,36 @@ export const threadInteractionCreate = async (props: {
   interaction: Interaction;
   commandType: string;
 }): Promise<void> => {
-  const threadName: string = pickOption(props.data.options, NAME_OPTION);
-  const rawUrl: string = pickOption(props.data.options, URL_OPTION);
-  const contents: string[] = rawUrl.split(" ").filter((i: string): boolean =>
-    i.length > 0,
-  );
+  const rawName: string = pickOption(props.data.options, NAME_OPTION);
+  const threadName: string = rawName.slice(0, MAX_NAME_IN_CUSTOM_ID);
 
   await props.b.helpers.sendInteractionResponse(
     props.interaction.id,
     props.interaction.token,
     {
-      type: InteractionResponseTypes.DeferredChannelMessageWithSource,
+      type: InteractionResponseTypes.Modal,
+      data: {
+        title: `Add URLs to "${threadName.slice(0, 40)}"`,
+        customId: `${props.commandType}|${threadName}`,
+        components: [
+          {
+            type: MessageComponentTypes.ActionRow,
+            components: [
+              {
+                type: MessageComponentTypes.InputText,
+                customId: URLS_INPUT_CUSTOM_ID,
+                style: TextStyles.Paragraph,
+                label: "Tweet URLs",
+                placeholder:
+                  "Paste one URL per line. Spaces / commas are also fine.",
+                required: true,
+                minLength: 1,
+                maxLength: 4000,
+              },
+            ],
+          },
+        ],
+      },
     },
   );
-
-  const allValid: boolean =
-    contents.length > 0 &&
-    contents.every((i: string): boolean => isUrl(i)) &&
-    threadName.length > 0;
-
-  await If(
-    !allValid,
-    async (): Promise<void> => {
-      await props.b.helpers.sendFollowupMessage(props.interaction.token, {
-        type: InteractionResponseTypes.ChannelMessageWithSource,
-        data: Messages.createErrorMessage({
-          description: contents.length > 0 ? contents.join("\n") : rawUrl,
-        }),
-      });
-    },
-  ).else(async (): Promise<void> => {
-    // Threads can only be created inside a guild text/announcement/forum
-    // channel. `interaction.channelId` is populated for DM interactions too
-    // (it's the DM channel ID), so also gate on `guildId` to ensure we are
-    // running in a guild context before calling `startThreadWithoutMessage`.
-    if (!props.interaction.channelId || !props.interaction.guildId) {
-      await props.b.helpers.sendFollowupMessage(props.interaction.token, {
-        type: InteractionResponseTypes.ChannelMessageWithSource,
-        data: Messages.createErrorMessage({
-          description: "This command must be used in a guild text channel.",
-        }),
-      });
-      return;
-    }
-
-    const thread = await props.b.helpers
-      .startThreadWithoutMessage(props.interaction.channelId, {
-        name: threadName,
-        autoArchiveDuration: Constants.Thread.AUTO_ARCHIVE_DURATION,
-        type: Constants.Thread.TYPE as ChannelTypes.PublicThread,
-      })
-      .catch(async (e: Error): Promise<null> => {
-        await props.b.helpers.sendFollowupMessage(props.interaction.token, {
-          type: InteractionResponseTypes.ChannelMessageWithSource,
-          data: Messages.createErrorMessage({
-            description: `Failed to create thread: ${e.message}`,
-          }),
-        });
-        return null;
-      });
-    if (!thread) return;
-
-    await props.b.helpers.sendFollowupMessage(props.interaction.token, {
-      type: InteractionResponseTypes.ChannelMessageWithSource,
-      data: {
-        content: `🧵 Created thread <#${thread.id}> for ${contents.length} URL(s).`,
-      },
-    });
-
-    const queueResults = await Promise.all(
-      contents.map(
-        async (
-          content: string,
-        ): Promise<{ link: string; message: string } | null> =>
-          await props.b.helpers
-            .sendMessage(
-              thread.id,
-              Messages.createProgressMessage({
-                content: `**🕑Queuing...**`,
-                link: content,
-              }),
-            )
-            .then((m: Message): { link: string; message: string } => ({
-              link: content,
-              message: `${m.id}`,
-            }))
-            .catch((): null => null),
-      ),
-    );
-    const links = queueResults.filter(
-      (i): i is { link: string; message: string } => i !== null,
-    );
-    if (links.length === 0) return;
-
-    await webhookThread({
-      commandType: props.commandType,
-      links,
-      channelId: thread.id,
-      token: props.interaction.token,
-      startTime: new Date().getTime().toString(),
-    }).catch(async (e: Error): Promise<KyResponse | void> => {
-      await Promise.all(
-        links.map(
-          async (i: { link: string; message: string }): Promise<Message> =>
-            await props.b.helpers.editMessage(
-              thread.id,
-              BigInt(i.message),
-              Messages.createErrorMessage({
-                link: i.link,
-                description: e.message,
-              }) as EditMessage,
-            ),
-        ),
-      );
-    });
-  });
 };

--- a/src/bot/threadModalSubmit.ts
+++ b/src/bot/threadModalSubmit.ts
@@ -1,0 +1,91 @@
+import { Bot, Interaction } from "discordeno";
+import { Constants } from "@libs";
+import { runThreadFlow } from "@bot/runThreadFlow.ts";
+import { URLS_INPUT_CUSTOM_ID } from "@bot/threadInteractionCreate.ts";
+
+type InteractionData = Exclude<Pick<Interaction, "data">["data"], undefined>;
+type InteractionDataComponents = Exclude<
+  Pick<InteractionData, "components">["components"],
+  undefined
+>;
+
+/**
+ * Allowlist of customId prefixes our ModalSubmit handler accepts. Anything
+ * else is silently ignored — `customId` is user-attacker-controllable in
+ * the sense that an arbitrary client could submit a forged ModalSubmit, so
+ * we never trust the prefix and only match exact known commandTypes.
+ */
+const ACCEPTED_COMMAND_TYPES = new Set<string>([
+  Constants.Webhook.Json.ClientPayload.CommandType.THREAD_DOWNLOAD,
+  Constants.Webhook.Json.ClientPayload.CommandType.THREAD_DOWNLOAD_SPOILER,
+]);
+
+/**
+ * Walks the (ActionRow → InputText) component tree and pulls the `value`
+ * field out of the InputText whose `customId === "urls"`. Returns `""` if
+ * the tree shape doesn't match (defensive — shouldn't happen with a Modal
+ * we built ourselves, but a forged ModalSubmit could).
+ */
+const extractUrlsFieldValue = (
+  components: InteractionDataComponents | undefined,
+): string => {
+  for (const row of components ?? []) {
+    for (const child of row.components ?? []) {
+      if (child.customId === URLS_INPUT_CUSTOM_ID) {
+        return child.value ?? "";
+      }
+    }
+  }
+  return "";
+};
+
+/**
+ * Handles a `ModalSubmit` interaction triggered by the user submitting the
+ * thread-URL Modal opened by `threadInteractionCreate`.
+ *
+ * Flow:
+ * 1. Validate the customId prefix is one we own (`threaddl` /
+ *    `threaddl-spoiler`). If not, do nothing — silently drop.
+ * 2. Extract the thread name from the customId tail.
+ * 3. Pull the multiline URL text from the Modal's TextInput, then grep out
+ *    every `https?://...` token via regex (delimiter-agnostic — newlines,
+ *    spaces, commas, you name it).
+ * 4. Hand the (commandType, threadName, urls) tuple off to the shared
+ *    `runThreadFlow` (same flow used by the legacy code path).
+ *
+ * @param props - Handler props bag.
+ * @param props.b - The bot instance.
+ * @param props.data - The interaction data object (ModalSubmit shape).
+ * @param props.interaction - The interaction object.
+ * @returns A promise that resolves when the dispatch completes.
+ */
+export const threadModalSubmit = async (props: {
+  b: Bot;
+  data: InteractionData;
+  interaction: Interaction;
+}): Promise<void> => {
+  const customId: string = props.data.customId ?? "";
+  const sepIdx = customId.indexOf("|");
+  if (sepIdx <= 0) return;
+
+  const commandType: string = customId.slice(0, sepIdx);
+  if (!ACCEPTED_COMMAND_TYPES.has(commandType)) return;
+
+  const threadName: string = customId.slice(sepIdx + 1);
+  const text: string = extractUrlsFieldValue(props.data.components);
+  // Delimiter-agnostic URL extraction (option #7). Lets users separate
+  // URLs by newlines, spaces, commas, or anything else without thinking
+  // about it. The character class deliberately excludes whitespace and
+  // common adjacent punctuation (`,`, `;`) so URLs like
+  // `https://x.com/u/1, https://x.com/u/2` aren't captured as one giant
+  // URL with a trailing comma.
+  const contents: string[] = text.match(/https?:\/\/[^\s,;]+/g) ?? [];
+
+  await runThreadFlow({
+    b: props.b,
+    interaction: props.interaction,
+    commandType,
+    threadName,
+    contents,
+  });
+};

--- a/src/libs/constants.ts
+++ b/src/libs/constants.ts
@@ -51,6 +51,7 @@ export const Constants = {
           DOWNLOAD: "dl",
           DOWNLOAD_SPOILER: "dl-spoiler",
           THREAD_DOWNLOAD: "threaddl",
+          THREAD_DOWNLOAD_SPOILER: "threaddl-spoiler",
         },
       },
     },
@@ -72,6 +73,7 @@ export const Constants = {
       DL: "dl",
       DL_SPOILER: "dl-spoiler",
       THREAD_DL: "threaddl",
+      THREAD_DL_SPOILER: "threaddl-spoiler",
     },
     actionType: {
       SINGLE: "single",

--- a/src/libs/custom.ts
+++ b/src/libs/custom.ts
@@ -40,15 +40,37 @@ export const Custom = {
           Constants.CallbackObject.actionType.THREAD_MULTI,
         ],
       },
+      ThreadDlSpoiler: {
+        Single: [
+          Constants.CallbackObject.Status.SUCCESS,
+          Constants.CallbackObject.commandType.THREAD_DL_SPOILER,
+          Constants.CallbackObject.actionType.THREAD_SINGLE,
+        ],
+        Multi: [
+          Constants.CallbackObject.Status.SUCCESS,
+          Constants.CallbackObject.commandType.THREAD_DL_SPOILER,
+          Constants.CallbackObject.actionType.THREAD_MULTI,
+        ],
+      },
     },
     FailureThread: [
       Constants.CallbackObject.Status.FAILURE,
       Constants.CallbackObject.commandType.THREAD_DL,
       P.nullish,
     ],
+    FailureThreadSpoiler: [
+      Constants.CallbackObject.Status.FAILURE,
+      Constants.CallbackObject.commandType.THREAD_DL_SPOILER,
+      P.nullish,
+    ],
     ProgressThread: [
       Constants.CallbackObject.Status.PROGRESS,
       Constants.CallbackObject.commandType.THREAD_DL,
+      P.nullish,
+    ],
+    ProgressThreadSpoiler: [
+      Constants.CallbackObject.Status.PROGRESS,
+      Constants.CallbackObject.commandType.THREAD_DL_SPOILER,
       P.nullish,
     ],
     Failure: [Constants.CallbackObject.Status.FAILURE, P.nullish, P.nullish],

--- a/src/router/callback.ts
+++ b/src/router/callback.ts
@@ -102,12 +102,38 @@ callback.post(
           }),
       )
       .with(
+        callbackPattern.Success.ThreadDlSpoiler.Single,
+        (): Promise<Response> =>
+          Functions.callbackSuccessFunctions.success.threadDlSpoiler.single({
+            c,
+            body,
+          }),
+      )
+      .with(
+        callbackPattern.Success.ThreadDlSpoiler.Multi,
+        (): Promise<Response> =>
+          Functions.callbackSuccessFunctions.success.threadDlSpoiler.multi({
+            c,
+            body,
+          }),
+      )
+      .with(
         callbackPattern.ProgressThread,
         (): Promise<Response> =>
           Functions.callbackProgressFunctions.progress({ c, body }),
       )
       .with(
+        callbackPattern.ProgressThreadSpoiler,
+        (): Promise<Response> =>
+          Functions.callbackProgressFunctions.progress({ c, body }),
+      )
+      .with(
         callbackPattern.FailureThread,
+        (): Promise<Response> =>
+          Functions.callbackFailureFunctions.failure({ c, body }),
+      )
+      .with(
+        callbackPattern.FailureThreadSpoiler,
         (): Promise<Response> =>
           Functions.callbackFailureFunctions.failure({ c, body }),
       )

--- a/src/router/functions/callbackFailureFunctions.ts
+++ b/src/router/functions/callbackFailureFunctions.ts
@@ -9,6 +9,7 @@ type InfoObject<T extends string> = CallbackTypes.infoObjectType<T>;
 const noContent = Constants.HttpStatus.NO_CONTENT;
 const internalServerError = Constants.HttpStatus.INTERNAL_SERVER_ERROR;
 const threadDl = Constants.CallbackObject.commandType.THREAD_DL;
+const threadDlSpoiler = Constants.CallbackObject.commandType.THREAD_DL_SPOILER;
 
 const callbackFailureFunctions: CallbackTypes.Functions.callbackFailure = {
   /**
@@ -20,7 +21,9 @@ const callbackFailureFunctions: CallbackTypes.Functions.callbackFailure = {
   failure: <T extends string>(infoObject: InfoObject<T>): Promise<Response> => {
     const runTime: number =
       new Date().getTime() - Number(infoObject.body!.startTime);
-    const useThread: boolean = infoObject.body!.commandType === threadDl;
+    const useThread: boolean =
+      infoObject.body!.commandType === threadDl ||
+      infoObject.body!.commandType === threadDlSpoiler;
     // editMessage (thread mode) is not bound by the 15-min interaction-token
     // window, so always edit the placeholder when running in a thread.
     const isEditOriginalMessage: boolean =

--- a/src/router/functions/callbackProgressFunctions.ts
+++ b/src/router/functions/callbackProgressFunctions.ts
@@ -9,6 +9,7 @@ type InfoObject<T extends string> = CallbackTypes.infoObjectType<T>;
 const noContent = Constants.HttpStatus.NO_CONTENT;
 const internalServerError = Constants.HttpStatus.INTERNAL_SERVER_ERROR;
 const threadDl = Constants.CallbackObject.commandType.THREAD_DL;
+const threadDlSpoiler = Constants.CallbackObject.commandType.THREAD_DL_SPOILER;
 
 const callbackProgressFunctions: CallbackTypes.Functions.callbackProgress = {
   /**
@@ -22,7 +23,9 @@ const callbackProgressFunctions: CallbackTypes.Functions.callbackProgress = {
   ): Promise<Response> => {
     const runTime: number =
       new Date().getTime() - Number(infoObject.body!.startTime);
-    const useThread: boolean = infoObject.body!.commandType === threadDl;
+    const useThread: boolean =
+      infoObject.body!.commandType === threadDl ||
+      infoObject.body!.commandType === threadDlSpoiler;
     // editMessage (thread mode) is not bound by the 15-min interaction-token
     // window, so always edit the placeholder when running in a thread.
     const isEditOriginalMessage: boolean =

--- a/src/router/functions/callbackSuccessFunctions.ts
+++ b/src/router/functions/callbackSuccessFunctions.ts
@@ -198,6 +198,30 @@ const callbackSuccessFunctions: CallbackTypes.Functions.callbackSuccess = {
         infoObject: InfoObject<T>,
       ): Promise<Response> => handleMultiSuccess(infoObject, false, true),
     },
+    threadDlSpoiler: {
+      /**
+       * Asynchronously handles a single callback success event for a thread
+       * download with spoiler. Uses `editMessage` (thread mode) and applies
+       * the `SPOILER_` filename prefix via `spoiler=true`.
+       *
+       * @param {InfoObject<T>} infoObject - The information object containing the necessary data for the callback success event.
+       * @return {Promise<Response>} A promise that resolves to a Response object.
+       */
+      single: <T extends string>(
+        infoObject: InfoObject<T>,
+      ): Promise<Response> => handleSingleSuccess(infoObject, true, true),
+      /**
+       * Asynchronously handles multi callback success events for a thread
+       * download with spoiler. Uses `editMessage` (thread mode) and applies
+       * the `SPOILER_` filename prefix via `spoiler=true`.
+       *
+       * @param {InfoObject<T>} infoObject - The information object containing the necessary data for the callback success event.
+       * @return {Promise<Response>} A promise that resolves to a Response object.
+       */
+      multi: <T extends string>(
+        infoObject: InfoObject<T>,
+      ): Promise<Response> => handleMultiSuccess(infoObject, true, true),
+    },
   },
 };
 

--- a/src/router/types/callbackTypes.ts
+++ b/src/router/types/callbackTypes.ts
@@ -5,7 +5,7 @@ export namespace CallbackTypes {
   export type bodyDataObject = {
     status: "success" | "failure" | "progress" | null;
     number: string;
-    commandType?: "dl" | "dl-spoiler" | "threaddl";
+    commandType?: "dl" | "dl-spoiler" | "threaddl" | "threaddl-spoiler";
     actionType?: "single" | "multi" | "thread-single" | "thread-multi";
     startTime: string;
     channel: string;

--- a/tests/bot/commands.test.ts
+++ b/tests/bot/commands.test.ts
@@ -35,23 +35,65 @@ Deno.test("Commands", async (t) => {
     assertEquals(url?.required, true);
   });
 
-  await t.step("threadDlCommand: maps to THREAD_DOWNLOAD + name + url options", () => {
-    assertEquals(
-      Commands.threadDlCommand.name,
-      Constants.Webhook.Json.ClientPayload.CommandType.THREAD_DOWNLOAD,
-    );
-    assertEquals(Commands.threadDlCommand.type, 1);
-    assertEquals(Commands.threadDlCommand.options?.length, 2);
+  await t.step(
+    "threadDlCommand: maps to THREAD_DOWNLOAD + only name option (URLs are collected via Modal)",
+    () => {
+      assertEquals(
+        Commands.threadDlCommand.name,
+        Constants.Webhook.Json.ClientPayload.CommandType.THREAD_DOWNLOAD,
+      );
+      assertEquals(Commands.threadDlCommand.type, 1);
+      // url option intentionally removed in the Modal-based flow
+      assertEquals(Commands.threadDlCommand.options?.length, 1);
 
-    const opts = Commands.threadDlCommand.options ?? [];
-    const optByName = Object.fromEntries(opts.map((o) => [o.name, o]));
+      const opts = Commands.threadDlCommand.options ?? [];
+      const optByName = Object.fromEntries(opts.map((o) => [o.name, o]));
 
-    assertEquals(optByName.name?.required, true);
-    assertEquals(optByName.name?.type, 3);
-    assertEquals(optByName.name?.description, "Thread Name");
+      assertEquals(optByName.name?.required, true);
+      assertEquals(optByName.name?.type, 3);
+      assertEquals(optByName.name?.description, "Thread Name");
 
-    assertEquals(optByName.url?.required, true);
-    assertEquals(optByName.url?.type, 3);
-    assertEquals(optByName.url?.description, "Tweet URL");
-  });
+      // url option no longer exists on the slash command — URLs come from
+      // the Modal that opens after the user invokes /threaddl
+      assertEquals(optByName.url, undefined);
+    },
+  );
+
+  await t.step(
+    "threadDlSpoilerCommand: maps to THREAD_DOWNLOAD_SPOILER + only name option (Modal-based)",
+    () => {
+      assertEquals(
+        Commands.threadDlSpoilerCommand.name,
+        Constants.Webhook.Json.ClientPayload.CommandType
+          .THREAD_DOWNLOAD_SPOILER,
+      );
+      assertEquals(Commands.threadDlSpoilerCommand.type, 1);
+      assertEquals(
+        Commands.threadDlSpoilerCommand.description,
+        "DL multiple Tweets into a thread with spoiler",
+      );
+      assertEquals(Commands.threadDlSpoilerCommand.options?.length, 1);
+
+      const opts = Commands.threadDlSpoilerCommand.options ?? [];
+      const optByName = Object.fromEntries(opts.map((o) => [o.name, o]));
+
+      assertEquals(optByName.name?.required, true);
+      assertEquals(optByName.name?.type, 3);
+      assertEquals(optByName.name?.description, "Thread Name");
+      assertEquals(optByName.url, undefined);
+    },
+  );
+
+  await t.step(
+    "threadDl ↔ threadDlSpoiler share the same options shape (parity check)",
+    () => {
+      const normal = (Commands.threadDlCommand.options ?? [])
+        .map((o) => ({ name: o.name, type: o.type, required: o.required }))
+        .sort((a, b) => a.name.localeCompare(b.name));
+      const spoiler = (Commands.threadDlSpoilerCommand.options ?? [])
+        .map((o) => ({ name: o.name, type: o.type, required: o.required }))
+        .sort((a, b) => a.name.localeCompare(b.name));
+      assertEquals(spoiler, normal);
+    },
+  );
 });

--- a/tests/bot/registerCommands.test.ts
+++ b/tests/bot/registerCommands.test.ts
@@ -17,7 +17,7 @@ Deno.test("registerCommands", async (t) => {
 
       await registerCommands(fakeBot);
 
-      assertSpyCalls(createGlobalApplicationCommand, 3);
+      assertSpyCalls(createGlobalApplicationCommand, 4);
       assertSpyCallArg(createGlobalApplicationCommand, 0, 0, Commands.dlCommand);
       assertSpyCallArg(
         createGlobalApplicationCommand,
@@ -30,6 +30,12 @@ Deno.test("registerCommands", async (t) => {
         2,
         0,
         Commands.threadDlCommand,
+      );
+      assertSpyCallArg(
+        createGlobalApplicationCommand,
+        3,
+        0,
+        Commands.threadDlSpoilerCommand,
       );
     },
   );
@@ -75,6 +81,8 @@ Deno.test("registerCommands", async (t) => {
         `end:${Commands.dlSpoilerCommand.name}`,
         `start:${Commands.threadDlCommand.name}`,
         `end:${Commands.threadDlCommand.name}`,
+        `start:${Commands.threadDlSpoilerCommand.name}`,
+        `end:${Commands.threadDlSpoilerCommand.name}`,
       ]);
     },
   );

--- a/tests/bot/threadInteractionCreate.test.ts
+++ b/tests/bot/threadInteractionCreate.test.ts
@@ -1,0 +1,165 @@
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { assertSpyCalls, spy } from "@std/testing/mock";
+import type { Spy } from "@std/testing/mock";
+import type { Bot, Interaction } from "discordeno";
+import {
+  InteractionResponseTypes,
+  MessageComponentTypes,
+  TextStyles,
+} from "discordeno";
+import {
+  MAX_NAME_IN_CUSTOM_ID,
+  threadInteractionCreate,
+  URLS_INPUT_CUSTOM_ID,
+} from "../../src/bot/threadInteractionCreate.ts";
+
+// deno-lint-ignore no-explicit-any
+type AnySpy = Spy<unknown, any[], any>;
+type FakeBot = { helpers: { sendInteractionResponse: AnySpy } };
+
+const makeFakeBot = (): FakeBot => ({
+  helpers: {
+    sendInteractionResponse: spy(() => Promise.resolve(undefined)),
+  },
+});
+
+const makeAppCommandInteraction = (name: string, threadName: string) =>
+  ({
+    id: 100n,
+    token: "fake-interaction-token",
+    data: {
+      name,
+      options: [{ name: "name", value: threadName, type: 3 }],
+    },
+  }) as unknown as Interaction;
+
+Deno.test("threadInteractionCreate (Modal opener)", async (t) => {
+  await t.step(
+    "/threaddl: responds with a Modal whose customId encodes commandType + threadName",
+    async () => {
+      const bot = makeFakeBot();
+      const interaction = makeAppCommandInteraction("threaddl", "My Thread");
+
+      await threadInteractionCreate({
+        b: bot as unknown as Bot,
+        data: interaction.data!,
+        interaction,
+        commandType: "threaddl",
+      });
+
+      assertSpyCalls(bot.helpers.sendInteractionResponse, 1);
+
+      const args = bot.helpers.sendInteractionResponse.calls[0].args;
+      assertEquals(args[0], 100n);
+      assertEquals(args[1], "fake-interaction-token");
+
+      const payload = args[2] as {
+        type: number;
+        data: {
+          title: string;
+          customId: string;
+          components: Array<{
+            type: number;
+            components: Array<{
+              type: number;
+              customId: string;
+              style: number;
+              label: string;
+              required: boolean;
+              minLength: number;
+              maxLength: number;
+            }>;
+          }>;
+        };
+      };
+      assertEquals(payload.type, InteractionResponseTypes.Modal);
+      assertEquals(payload.data.customId, "threaddl|My Thread");
+      assertStringIncludes(payload.data.title, "My Thread");
+
+      assertEquals(payload.data.components.length, 1);
+      const row = payload.data.components[0];
+      assertEquals(row.type, MessageComponentTypes.ActionRow);
+      assertEquals(row.components.length, 1);
+
+      const input = row.components[0];
+      assertEquals(input.type, MessageComponentTypes.InputText);
+      assertEquals(input.customId, URLS_INPUT_CUSTOM_ID);
+      assertEquals(input.style, TextStyles.Paragraph);
+      assertEquals(input.required, true);
+      assertEquals(input.minLength, 1);
+      assertEquals(input.maxLength, 4000);
+    },
+  );
+
+  await t.step(
+    "/threaddl-spoiler: customId carries the spoiler commandType prefix",
+    async () => {
+      const bot = makeFakeBot();
+      const interaction = makeAppCommandInteraction(
+        "threaddl-spoiler",
+        "Hidden",
+      );
+
+      await threadInteractionCreate({
+        b: bot as unknown as Bot,
+        data: interaction.data!,
+        interaction,
+        commandType: "threaddl-spoiler",
+      });
+
+      const args = bot.helpers.sendInteractionResponse.calls[0].args;
+      const payload = args[2] as { data: { customId: string } };
+      assertEquals(payload.data.customId, "threaddl-spoiler|Hidden");
+    },
+  );
+
+  await t.step(
+    "long thread name is truncated to fit within the 100-char customId limit",
+    async () => {
+      const bot = makeFakeBot();
+      const longName = "A".repeat(200);
+      const interaction = makeAppCommandInteraction("threaddl", longName);
+
+      await threadInteractionCreate({
+        b: bot as unknown as Bot,
+        data: interaction.data!,
+        interaction,
+        commandType: "threaddl",
+      });
+
+      const args = bot.helpers.sendInteractionResponse.calls[0].args;
+      const payload = args[2] as { data: { customId: string } };
+      assertEquals(payload.data.customId.length <= 100, true);
+      // commandType prefix + separator + truncated name
+      assertEquals(
+        payload.data.customId,
+        `threaddl|${"A".repeat(MAX_NAME_IN_CUSTOM_ID)}`,
+      );
+    },
+  );
+
+  await t.step(
+    "missing name option: still returns a Modal (with empty name in customId)",
+    async () => {
+      const bot = makeFakeBot();
+      const interaction = {
+        id: 1n,
+        token: "tok",
+        data: { name: "threaddl", options: [] },
+      } as unknown as Interaction;
+
+      await threadInteractionCreate({
+        b: bot as unknown as Bot,
+        data: interaction.data!,
+        interaction,
+        commandType: "threaddl",
+      });
+
+      assertSpyCalls(bot.helpers.sendInteractionResponse, 1);
+      const args = bot.helpers.sendInteractionResponse.calls[0].args;
+      const payload = args[2] as { type: number; data: { customId: string } };
+      assertEquals(payload.type, InteractionResponseTypes.Modal);
+      assertEquals(payload.data.customId, "threaddl|");
+    },
+  );
+});

--- a/tests/bot/threadModalSubmit.test.ts
+++ b/tests/bot/threadModalSubmit.test.ts
@@ -1,0 +1,326 @@
+import { assertEquals } from "@std/assert";
+import { assertSpyCalls, spy, stub } from "@std/testing/mock";
+import type { Spy } from "@std/testing/mock";
+import type { Bot, Interaction, Message } from "discordeno";
+import { threadModalSubmit } from "../../src/bot/threadModalSubmit.ts";
+
+// deno-lint-ignore no-explicit-any
+type AnySpy = Spy<unknown, any[], any>;
+
+type FakeBot = {
+  helpers: {
+    sendInteractionResponse: AnySpy;
+    sendFollowupMessage: AnySpy;
+    startThreadWithoutMessage: AnySpy;
+    sendMessage: AnySpy;
+    editMessage: AnySpy;
+  };
+};
+
+/**
+ * Bot fake that lets `runThreadFlow` walk through the happy path:
+ * - sendInteractionResponse / sendFollowupMessage just resolve
+ * - startThreadWithoutMessage returns a fake thread with id=42n
+ * - sendMessage returns Messages with sequential ids so the eventual
+ *   `webhookThread` payload has unique `message` strings per URL
+ */
+const makeFakeBot = (): FakeBot => {
+  let nextMsgId = 1n;
+  return {
+    helpers: {
+      sendInteractionResponse: spy(() => Promise.resolve(undefined)),
+      sendFollowupMessage: spy((_t: string, _p: unknown) =>
+        Promise.resolve({ id: 999n, channelId: 111n } as unknown as Message)
+      ),
+      startThreadWithoutMessage: spy((_chan: bigint, _opts: unknown) =>
+        Promise.resolve({ id: 42n } as { id: bigint })
+      ),
+      sendMessage: spy((_chan: bigint, _payload: unknown) => {
+        const id = nextMsgId++;
+        return Promise.resolve({ id, channelId: 42n } as unknown as Message);
+      }),
+      editMessage: spy(() =>
+        Promise.resolve({} as unknown as Message)
+      ),
+    },
+  };
+};
+
+const makeModalSubmitInteraction = (
+  customId: string,
+  urlsValue: string,
+  opts: { channelId?: bigint; guildId?: bigint | undefined } = {},
+): Interaction => {
+  // Note: explicit `in` check so callers can pass `guildId: undefined`
+  // (DM context) and have it actually be undefined, rather than
+  // `?? 500n` silently substituting a default.
+  const channelId = "channelId" in opts ? opts.channelId : 100n;
+  const guildId = "guildId" in opts ? opts.guildId : 500n;
+  return {
+    id: 200n,
+    token: "fake-modal-token",
+    type: 5, // InteractionTypes.ModalSubmit
+    channelId,
+    guildId,
+    data: {
+      customId,
+      components: [
+        {
+          type: 1, // ActionRow
+          components: [
+            {
+              type: 4, // InputText
+              customId: "urls",
+              value: urlsValue,
+            },
+          ],
+        },
+      ],
+    },
+  } as unknown as Interaction;
+};
+
+const stubFetchOk = () =>
+  stub(
+    globalThis,
+    "fetch",
+    () =>
+      Promise.resolve(
+        new Response("{}", {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      ),
+  );
+
+Deno.test("threadModalSubmit", async (t) => {
+  await t.step(
+    "valid /threaddl submit with newline-separated URLs: creates a thread + N queue messages + 1 webhook",
+    async () => {
+      const bot = makeFakeBot();
+      const text =
+        "https://twitter.com/u/status/1\nhttps://twitter.com/u/status/2\nhttps://twitter.com/u/status/3";
+      const interaction = makeModalSubmitInteraction("threaddl|My Thread", text);
+      const fetchStub = stubFetchOk();
+
+      try {
+        await threadModalSubmit({
+          b: bot as unknown as Bot,
+          data: interaction.data!,
+          interaction,
+        });
+
+        // 1 Defer ACK + 1 "thread created" followup
+        assertSpyCalls(bot.helpers.sendInteractionResponse, 1);
+        assertSpyCalls(bot.helpers.sendFollowupMessage, 1);
+
+        // Thread creation w/ the parsed thread name
+        assertSpyCalls(bot.helpers.startThreadWithoutMessage, 1);
+        const startArgs = bot.helpers.startThreadWithoutMessage.calls[0].args;
+        assertEquals(startArgs[0], 100n); // channelId
+        assertEquals(
+          (startArgs[1] as { name: string }).name,
+          "My Thread",
+        );
+
+        // 3 queue messages, one per URL
+        assertSpyCalls(bot.helpers.sendMessage, 3);
+
+        // exactly 1 repository_dispatch fan-out
+        assertSpyCalls(fetchStub, 1);
+        const fetchArg0 = fetchStub.calls[0].args[0];
+        const req =
+          fetchArg0 instanceof Request
+            ? fetchArg0
+            : new Request(fetchArg0 as string, fetchStub.calls[0]
+                .args[1] as RequestInit | undefined);
+        const body = JSON.parse(await req.text()) as {
+          event_type: string;
+          client_payload: {
+            commandType: string;
+            channel: string;
+            links: Array<{ link: string; message: string }>;
+          };
+        };
+        assertEquals(body.event_type, "thread-download");
+        assertEquals(body.client_payload.commandType, "threaddl");
+        assertEquals(body.client_payload.channel, "42");
+        assertEquals(body.client_payload.links.length, 3);
+        assertEquals(
+          body.client_payload.links.map((l) => l.link),
+          [
+            "https://twitter.com/u/status/1",
+            "https://twitter.com/u/status/2",
+            "https://twitter.com/u/status/3",
+          ],
+        );
+      } finally {
+        fetchStub.restore();
+      }
+    },
+  );
+
+  await t.step(
+    "/threaddl-spoiler submit: forwards spoiler commandType into the dispatch payload",
+    async () => {
+      const bot = makeFakeBot();
+      const interaction = makeModalSubmitInteraction(
+        "threaddl-spoiler|Hidden",
+        "https://twitter.com/u/status/1",
+      );
+      const fetchStub = stubFetchOk();
+
+      try {
+        await threadModalSubmit({
+          b: bot as unknown as Bot,
+          data: interaction.data!,
+          interaction,
+        });
+
+        assertSpyCalls(fetchStub, 1);
+        const fetchArg0 = fetchStub.calls[0].args[0];
+        const req =
+          fetchArg0 instanceof Request
+            ? fetchArg0
+            : new Request(fetchArg0 as string, fetchStub.calls[0]
+                .args[1] as RequestInit | undefined);
+        const body = JSON.parse(await req.text()) as {
+          client_payload: { commandType: string };
+        };
+        assertEquals(body.client_payload.commandType, "threaddl-spoiler");
+      } finally {
+        fetchStub.restore();
+      }
+    },
+  );
+
+  await t.step(
+    "delimiter-agnostic URL extraction: spaces, commas, newlines, mixed",
+    async () => {
+      const bot = makeFakeBot();
+      const text =
+        "https://twitter.com/u/status/1, https://twitter.com/u/status/2\n  https://twitter.com/u/status/3 https://twitter.com/u/status/4";
+      const interaction = makeModalSubmitInteraction("threaddl|t", text);
+      const fetchStub = stubFetchOk();
+
+      try {
+        await threadModalSubmit({
+          b: bot as unknown as Bot,
+          data: interaction.data!,
+          interaction,
+        });
+
+        // 4 queue messages → 4 URLs were extracted
+        assertSpyCalls(bot.helpers.sendMessage, 4);
+      } finally {
+        fetchStub.restore();
+      }
+    },
+  );
+
+  await t.step(
+    "no URLs in submitted text: posts an error followup, never creates a thread",
+    async () => {
+      const bot = makeFakeBot();
+      const interaction = makeModalSubmitInteraction(
+        "threaddl|t",
+        "no urls here at all",
+      );
+      const fetchStub = stubFetchOk();
+
+      try {
+        await threadModalSubmit({
+          b: bot as unknown as Bot,
+          data: interaction.data!,
+          interaction,
+        });
+
+        assertSpyCalls(bot.helpers.sendInteractionResponse, 1); // Defer ACK
+        assertSpyCalls(bot.helpers.sendFollowupMessage, 1); // error embed
+        assertSpyCalls(bot.helpers.startThreadWithoutMessage, 0);
+        assertSpyCalls(bot.helpers.sendMessage, 0);
+        assertSpyCalls(fetchStub, 0);
+      } finally {
+        fetchStub.restore();
+      }
+    },
+  );
+
+  await t.step(
+    "DM context (guildId missing): rejects before creating a thread",
+    async () => {
+      const bot = makeFakeBot();
+      const interaction = makeModalSubmitInteraction(
+        "threaddl|t",
+        "https://twitter.com/u/status/1",
+        { guildId: undefined },
+      );
+      const fetchStub = stubFetchOk();
+
+      try {
+        await threadModalSubmit({
+          b: bot as unknown as Bot,
+          data: interaction.data!,
+          interaction,
+        });
+
+        assertSpyCalls(bot.helpers.startThreadWithoutMessage, 0);
+        assertSpyCalls(fetchStub, 0);
+      } finally {
+        fetchStub.restore();
+      }
+    },
+  );
+
+  await t.step(
+    "unknown customId prefix: silently dropped (no Defer, no fetch, no thread)",
+    async () => {
+      const bot = makeFakeBot();
+      const interaction = makeModalSubmitInteraction(
+        "evilbot|payload",
+        "https://twitter.com/u/status/1",
+      );
+      const fetchStub = stubFetchOk();
+
+      try {
+        await threadModalSubmit({
+          b: bot as unknown as Bot,
+          data: interaction.data!,
+          interaction,
+        });
+
+        assertSpyCalls(bot.helpers.sendInteractionResponse, 0);
+        assertSpyCalls(bot.helpers.sendFollowupMessage, 0);
+        assertSpyCalls(bot.helpers.startThreadWithoutMessage, 0);
+        assertSpyCalls(fetchStub, 0);
+      } finally {
+        fetchStub.restore();
+      }
+    },
+  );
+
+  await t.step(
+    "customId without separator: silently dropped",
+    async () => {
+      const bot = makeFakeBot();
+      const interaction = makeModalSubmitInteraction(
+        "threaddl",
+        "https://twitter.com/u/status/1",
+      );
+      const fetchStub = stubFetchOk();
+
+      try {
+        await threadModalSubmit({
+          b: bot as unknown as Bot,
+          data: interaction.data!,
+          interaction,
+        });
+
+        assertSpyCalls(bot.helpers.sendInteractionResponse, 0);
+        assertSpyCalls(fetchStub, 0);
+      } finally {
+        fetchStub.restore();
+      }
+    },
+  );
+});


### PR DESCRIPTION
## Summary

Two-in-one PR — implements both:
1. **Multi-URL input UX overhaul** for `/threaddl`: switches from a `url:"u1 u2 u3"` slash-command option to a Discord **Modal** with a Paragraph TextInput (option #1 + #7 from the prior research).
2. **`/threaddl-spoiler`**: new command that mirrors `/threaddl` but adds `SPOILER_` to uploaded file names — same Modal entry point, same dispatch path, just `commandType="threaddl-spoiler"` in the customId / callback payload.

> **⚠️ Breaking change**: `/threaddl` no longer takes a `url` option. URLs are now collected from the Modal that opens on invocation. Callers of the slash command via existing scripts/macros need to migrate to interactive use.

## Architecture (Mermaid)

```mermaid
sequenceDiagram
  actor U as User (Discord)
  participant B as Bot
  participant DC as Discord (Thread)
  participant GH as GitHub Actions

  U->>B: /threaddl name:Foo  (or /threaddl-spoiler name:Foo)
  B-->>U: Modal (TextInput, customId="threaddl|Foo")
  U->>B: ModalSubmit (urls field text, customId)
  B->>B: validate customId prefix in allowlist
  B->>B: extract URLs via /https?:\/\/[^\s,;]+/g
  B-->>U: Defer (DeferredChannelMessageWithSource)
  B->>DC: startThreadWithoutMessage(channel, {name})
  DC-->>B: thread channel id
  B->>DC: sendMessage(thread, "Queuing...") × N
  B->>GH: repository_dispatch (thread-download)<br/>{ commandType: "threaddl"|"threaddl-spoiler",<br/>  channel, links: [{link, message}, ...] }
  par 並列実行 (max-parallel: 16)
    GH->>GH: download[shard 1] (yt-dlp + ffmpeg)
    GH->>GH: download[shard N] ...
  end
  GH-->>B: callback (per shard)<br/>commandType=threaddl|threaddl-spoiler<br/>actionType=thread-single|thread-multi
  B->>DC: editMessage(thread, queueMsgId, result)<br/>(SPOILER_ prefix when commandType=threaddl-spoiler)
```

## Phase-by-phase changes

### Phase 1 — extract `runThreadFlow`
- **NEW** `src/bot/runThreadFlow.ts`: pure validate → create thread → queue messages → dispatch flow. Takes already-extracted URLs (no parsing inside).
- Lets the Modal path and any future ApplicationCommand path share the same flow.

### Phase 2 — Modal-based `/threaddl`
- `src/bot/commands.ts`: removed the `url` option from `threadDlCommand`. Only `name` remains.
- `src/bot/threadInteractionCreate.ts` (rewritten): now just opens a Modal as the immediate response. customId encodes `"<commandType>|<threadName>"` (truncated to 80 chars to stay under Discord's 100-char `customId` limit).
- **NEW** `src/bot/threadModalSubmit.ts`:
  - validates the customId prefix against an **allowlist** (`Set<{"threaddl", "threaddl-spoiler"}>`) so a forged ModalSubmit can't trigger this handler with arbitrary commandTypes
  - extracts URLs via `match(/https?:\/\/[^\s,;]+/g)` — delimiter-agnostic, strips trailing `,` / `;`
  - delegates to `runThreadFlow`
- `src/bot/bot.ts`: dispatcher now branches on `interaction.type`:
  - `ModalSubmit` → `threadModalSubmit`
  - `ApplicationCommand` → existing per-command-name match

### Phase 3 — `/threaddl-spoiler`
- `src/bot/commands.ts` + `registerCommands.ts`: new `threadDlSpoilerCommand`, registration order is now `dl → dl-spoiler → threaddl → threaddl-spoiler`.
- `src/libs/constants.ts`:
  - `Webhook.Json.ClientPayload.CommandType.THREAD_DOWNLOAD_SPOILER = "threaddl-spoiler"`
  - `CallbackObject.commandType.THREAD_DL_SPOILER = "threaddl-spoiler"`
- `src/libs/custom.ts`: `Success.ThreadDlSpoiler.{Single,Multi}`, `ProgressThreadSpoiler`, `FailureThreadSpoiler` patterns. Spoiler-specific patterns are matched **before** the non-spoiler ones in `callback.ts` (first-match wins).
- `src/router/callback.ts`: routes the new patterns to:
  - `callbackSuccessFunctions.success.threadDlSpoiler.{single,multi}` — calls `handleSingleSuccess` / `handleMultiSuccess` with `(spoiler=true, useThread=true)`, so the existing `successMessage` code path applies the `SPOILER_` filename prefix
  - `callbackProgressFunctions.progress` / `callbackFailureFunctions.failure` — widened their `useThread` derivation to include `commandType === threaddl-spoiler`
- `src/router/types/callbackTypes.ts`: extended `commandType` union with `"threaddl-spoiler"`.
- **`run-thread.yml` is unchanged.** Same workflow handles both threaddl variants — `commandType` is forwarded from `client_payload` to the callback HTTP body as a string, the same way `run.yml` handles `/dl` ↔ `/dl-spoiler`. No new event_type, no parallel workflow, no diff hell.

### Phase 4 — tests
- `tests/bot/commands.test.ts`: updated `threadDlCommand` step to assert the `url` option is removed; added `threadDlSpoilerCommand` step + parity assertion across both thread commands.
- `tests/bot/registerCommands.test.ts`: 4-command expectations + sequential-await trace updated.
- **NEW** `tests/bot/threadInteractionCreate.test.ts`: covers Modal customId encoding (`/threaddl`, `/threaddl-spoiler`), long-name truncation (≤100 chars), missing-name fallback.
- **NEW** `tests/bot/threadModalSubmit.test.ts`:
  - happy path: 3-URL submit fans out 1 thread + 3 queue messages + 1 webhook
  - spoiler path: forwarded `commandType` in webhook payload
  - delimiter-agnostic extraction: spaces / commas / newlines mixed in one input
  - no-URL submit → error embed, no thread
  - DM context (guildId missing) → guard rejects
  - forged customId prefix → silently dropped

## Existing /dl, /dl-spoiler, /threaddl behavior

- `/dl`, `/dl-spoiler`: completely untouched. Same `interactionCreate.ts`, same `webhook` helper, same `run.yml`.
- `/threaddl`: **breaking change** to the slash command shape (no more `url` option). The thread-creation downstream is identical, just the input layer changed.

## Verification

- ✅ `deno check src/main.ts` — clean
- ✅ `deno lint` — clean
- ✅ `deno task test` — **12 tests / 57 steps pass** (with `.env` temporarily moved aside; local `.env` overrides task-level `DISPATCH_URL` via unienv auto-loading and breaks the pre-existing `interactionCreate.test.ts` URL-prefix assertion. CI doesn't ship a `.env`, so this is a local-dev-only quirk and not introduced by this PR.)

## 動作確認チェックリスト (実機ユーザー向け)

- [ ] `/threaddl name:test` を実行 → URL 入力 Modal が開く
- [ ] Modal に 1 URL 1 行で複数貼り付け → 送信 → 指定名のスレッドが作成され、各 URL の placeholder + DL 結果がスレッド内に並ぶ
- [ ] `/threaddl-spoiler name:hidden` で同様、ファイル名に `SPOILER_` prefix が付く
- [ ] Modal にカンマ区切りやスペース区切りの URL を混ぜる → ちゃんと拾われる
- [ ] Modal を空送信 / 非 URL テキスト送信 → エラー embed
- [ ] DM で `/threaddl` 実行 → ガードで拒否される
- [ ] `/dl <URL>` / `/dl-spoiler <URL>` が回帰せず動く
- [ ] 17+ URL 投入時に matrix が `max-parallel: 16` で頭打ちになる

## Notes

- Custom ID slicing: thread name truncated to 80 chars to stay under the 100-char customId cap. Display title in the Modal also truncated to ≤40 chars (Discord's title cap). Names longer than 80 chars are uncommon for thread titles, but if you hit it the Modal is still functional, just with a slightly truncated thread name.
- `runThreadFlow` is intentionally exported for future reuse (e.g. context-menu commands, or if we ever want a power-user `/threaddl-direct` that bypasses the Modal). Not used outside the Modal path today.
- Documentation (`README.md`, `docs/commands.md`) — *not* updated in this PR to keep the diff tight; suggest a follow-up PR (or include in task #8 docs sync).