### PR TITLE
ci: switch Codecov upload to token-based auth

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,6 +55,4 @@ jobs:
           files: ./coverage.lcov
           flags: deno
           fail_ci_if_error: false
-          # Public repo + the Codecov GitHub App is installed on this org,
-          # so tokenless upload works. If that ever breaks, set
-          # `secrets.CODECOV_TOKEN` and add `token: ${{ secrets.CODECOV_TOKEN }}`.
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary

- `CODECOV_TOKEN` repository secret を `codecov/codecov-action@v5` の `token:` パラメータに追加
- tokenless upload 想定だった古いコメント（`# Public repo + the Codecov GitHub App is installed...`）を削除

## 背景・切替理由

PR #8 では Codecov GitHub App 経由の tokenless upload を想定して設定しましたが、実際には upload が成功しませんでした。メンテナー（redpeacock78 さん）が `CODECOV_TOKEN` を GitHub repository secret として追加済みのため、それを参照する形に切替します。

## 変更内容

`.github/workflows/test.yml` の `Upload coverage to Codecov` step:

```yaml
# Before (tokenless + comment only)
with:
  files: ./coverage.lcov
  flags: deno
  fail_ci_if_error: false
  # Public repo + the Codecov GitHub App is installed on this org,
  # so tokenless upload works. If that ever breaks, set
  # `secrets.CODECOV_TOKEN` and add `token: ${{ secrets.CODECOV_TOKEN }}`.

# After (token-based)
with:
  files: ./coverage.lcov
  flags: deno
  fail_ci_if_error: false
  token: ${{ secrets.CODECOV_TOKEN }}
```

## Test plan

- [ ] CI の `Upload coverage to Codecov` step が token 経由で認証通過し、Codecov にレポートが届くことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)