### PR TITLE
refactor(style): unify Match import source and variable naming

### DIFF
--- a/src/router/functions/callbackFailureFunctions.ts
+++ b/src/router/functions/callbackFailureFunctions.ts
@@ -1,5 +1,5 @@
 import bot from "@bot/bot.ts";
-import { match } from "ts-pattern";
+import { Match } from "functional";
 import { EditMessage } from "discordeno";
 import { Constants, Messages } from "@libs";
 import { CallbackTypes } from "@router/types/callbackTypes.ts";
@@ -28,7 +28,7 @@ const callbackFailureFunctions: CallbackTypes.Functions.callbackFailure = {
     // window, so always edit the placeholder when running in a thread.
     const isEditOriginalMessage: boolean =
       useThread || runTime <= Constants.EDIT_FOLLOWUP_MESSAGE_TIME_LIMIT;
-    return match(isEditOriginalMessage)
+    return Match(isEditOriginalMessage)
       .with(
         true,
         (): Promise<Response> =>

--- a/src/router/functions/callbackProgressFunctions.ts
+++ b/src/router/functions/callbackProgressFunctions.ts
@@ -1,5 +1,5 @@
 import bot from "@bot/bot.ts";
-import { match } from "ts-pattern";
+import { Match } from "functional";
 import { EditMessage } from "discordeno";
 import { Constants, Messages } from "@libs";
 import { CallbackTypes } from "@router/types/callbackTypes.ts";
@@ -30,7 +30,7 @@ const callbackProgressFunctions: CallbackTypes.Functions.callbackProgress = {
     // window, so always edit the placeholder when running in a thread.
     const isEditOriginalMessage: boolean =
       useThread || runTime <= Constants.EDIT_FOLLOWUP_MESSAGE_TIME_LIMIT;
-    return match(isEditOriginalMessage)
+    return Match(isEditOriginalMessage)
       .with(
         true,
         (): Promise<Response> =>

--- a/src/router/messages/successMessage.ts
+++ b/src/router/messages/successMessage.ts
@@ -105,11 +105,11 @@ const successMessage = {
     // editMessage (thread mode) is not bound by the 15-min interaction-token
     // window or the followup oversize fallback, so always edit the
     // placeholder when running in a thread.
-    const editOriginalMessageFlag: boolean =
+    const isEditOriginalMessage: boolean =
       useThread ||
       runTime <= editFollowupMessageTimeLimit ||
       multiSuccsessMessageObject!.oversize !== trueOversize;
-    return Match(editOriginalMessageFlag)
+    return Match(isEditOriginalMessage)
       .with(
         true,
         async (): Promise<Message> =>


### PR DESCRIPTION
## Summary

Two cosmetic inconsistencies corrected — **zero behavioral change**.

### Change 1 — `ts-pattern` direct import → `functional` barrel (`Match`)

`callbackProgressFunctions.ts` and `callbackFailureFunctions.ts` were importing `match` directly from `ts-pattern`:
```ts
// before
import { match } from "ts-pattern";
return match(isEditOriginalMessage)
```

All other files (`successMessage.ts`, `errorMessage.ts`, `bot.ts`, `callback.ts`) already use the `functional` barrel which re-exports it as `Match`. Aligned both files to the same pattern:
```ts
// after
import { Match } from "functional";
return Match(isEditOriginalMessage)
```

### Change 2 — `editOriginalMessageFlag` → `isEditOriginalMessage` in `successMessage.ts`

`multiFiles` used a different variable name (`editOriginalMessageFlag`) for the same boolean semantics as `singleFile`'s `isEditOriginalMessage` in the same file. Renamed to match.

## Why minimal — Phase B/C not implemented

Full codebase audit was conducted before this PR. Two additional candidates were evaluated and rejected:

- **Phase B** (`isThreadCommandType` helper extraction): only 3 lines × 2 call sites; extracting adds a new module without meaningfully simplifying either file. Cost > benefit.
- **Phase C** (`isEmptyObj` barrel removal): only exported, never called from `src/`. Removing is a breaking change relative to any external consumer. Benefit too small.

The codebase is already well-factored after PRs #6/#7/#9 and the workflow refactors. This PR touches only what genuinely needed alignment.

## Test plan

- [x] `deno check --allow-import src/main.ts` — clean
- [x] `deno lint src/` — clean (43 files)
- [x] `deno task test` — **24 passed (112 steps) | 0 failed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)