### PR TITLE
perf: drop GuildMessages and MessageContent gateway intents

### DIFF
--- a/src/bot/bot.ts
+++ b/src/bot/bot.ts
@@ -14,7 +14,7 @@ import { threadModalSubmit } from "@bot/threadModalSubmit.ts";
 
 const bot: Bot = createBot({
   token: Secrets.DISCORD_TOKEN,
-  intents: Intents.Guilds | Intents.GuildMessages | Intents.MessageContent,
+  intents: Intents.Guilds,
   events: {
     ready: (_bot, payload) => {
       console.log(`${payload.user.username} is ready!`);


### PR DESCRIPTION
## Summary

- The bot only consumes `INTERACTION_CREATE` events — it never reads guild messages or inspects message content.
- Subscribing to `GuildMessages` and `MessageContent` caused discordeno to build and maintain message/member caches for every guild message sent anywhere, burning memory on events the bot ignores.
- `intents` reduced to `Intents.Guilds` only.

## Test plan

- [x] `deno check --allow-import src/main.ts` — clean
- [x] `deno lint src/` — clean
- [x] `deno task test` — 24 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)