### PR TITLE
feat: hide /threaddl and /threaddl-spoiler from DM autocomplete

### DIFF
--- a/src/bot/commands.ts
+++ b/src/bot/commands.ts
@@ -41,10 +41,18 @@ export const Commands: CommandsType = {
   // many URLs without worrying about quoting/escaping.
   // The slash command itself only takes `name` (the thread title), and the
   // bot opens the Modal as the immediate interaction response.
+  //
+  // `dmPermission: false` hides both commands from DM autocomplete. Thread
+  // creation requires a guild text channel — there is no valid DM use-case.
+  // discordeno v18 exposes `dmPermission` from the Discord API v10
+  // `CreateSlashApplicationCommand` shape. The newer `contexts` field (Discord
+  // API v10 addition) is not yet present in this version's type; `dmPermission`
+  // achieves the same result and is still honoured by all current clients.
   threadDlCommand: {
     name: Constants.Webhook.Json.ClientPayload.CommandType.THREAD_DOWNLOAD,
     description: "DL multiple Tweets into a thread",
     type: 1,
+    dmPermission: false,
     options: [
       {
         name: "name",
@@ -59,6 +67,7 @@ export const Commands: CommandsType = {
       Constants.Webhook.Json.ClientPayload.CommandType.THREAD_DOWNLOAD_SPOILER,
     description: "DL multiple Tweets into a thread with spoiler",
     type: 1,
+    dmPermission: false,
     options: [
       {
         name: "name",

--- a/src/bot/runThreadFlow.ts
+++ b/src/bot/runThreadFlow.ts
@@ -78,6 +78,12 @@ export const runThreadFlow = async (props: {
     // channel. `interaction.channelId` is populated for DM interactions too
     // (it's the DM channel ID), so also gate on `guildId` to ensure we are
     // running in a guild context before calling `startThreadWithoutMessage`.
+    //
+    // NOTE: `/threaddl` and `/threaddl-spoiler` are registered with
+    // `dmPermission: false` so Discord clients should never surface them in
+    // DMs. This guard is kept as a defensive measure against stale client-side
+    // command caches — Discord propagates command updates within ~1 hour, so a
+    // small window exists where users may still see the old definition.
     if (!props.interaction.channelId || !props.interaction.guildId) {
       await props.b.helpers.sendFollowupMessage(props.interaction.token, {
         type: InteractionResponseTypes.ChannelMessageWithSource,

--- a/tests/bot/commands.test.ts
+++ b/tests/bot/commands.test.ts
@@ -96,4 +96,30 @@ Deno.test("Commands", async (t) => {
       assertEquals(spoiler, normal);
     },
   );
+
+  await t.step(
+    "threadDlCommand: dmPermission=false (guild-only, hidden from DM autocomplete)",
+    () => {
+      // dmPermission: false tells Discord not to surface this command in DMs.
+      // Thread creation requires a guild text channel — DMs have no valid
+      // use-case for this command.
+      assertEquals(Commands.threadDlCommand.dmPermission, false);
+    },
+  );
+
+  await t.step(
+    "threadDlSpoilerCommand: dmPermission=false (guild-only, hidden from DM autocomplete)",
+    () => {
+      assertEquals(Commands.threadDlSpoilerCommand.dmPermission, false);
+    },
+  );
+
+  await t.step(
+    "dlCommand + dlSpoilerCommand: dmPermission not set (DM usable)",
+    () => {
+      // /dl and /dl-spoiler work in DMs — only the thread variants require a guild.
+      assertEquals(Commands.dlCommand.dmPermission, undefined);
+      assertEquals(Commands.dlSpoilerCommand.dmPermission, undefined);
+    },
+  );
 });


### PR DESCRIPTION
## Summary

- `/threaddl` and `/threaddl-spoiler` now have `dmPermission: false` in their command definitions. Discord will no longer surface them in DM autocomplete.
- `/dl` and `/dl-spoiler` are **not changed** — they remain DM-usable.
- `runThreadFlow`'s `guildId` guard is **retained** as a defensive fallback (see below).

## API choice: `dmPermission` vs `contexts`

discordeno v18's `CreateSlashApplicationCommand` type exposes `dmPermission?: boolean` from the Discord API v10 command shape. The newer `contexts?: DiscordInteractionContextType[]` field (also part of API v10, which restricts by interaction context type) is not present in this library version's TypeScript types — setting it causes a TS2353 type error. `dmPermission: false` achieves the same practical result and is honoured by all current Discord clients.

## Why the `guildId` guard in `runThreadFlow` is kept

Discord propagates command-definition updates to clients within approximately **1 hour**. During that window, users with a stale command cache may still see `/threaddl` in DMs and invoke it. The guard ensures they receive a clear error embed rather than an unhandled exception. The guard comment has been updated to document this reasoning.

## Test plan

- [x] `deno check --allow-import src/main.ts` — clean
- [x] `deno lint src/` — clean
- [x] `deno task test` — 26 passed, 0 failed
  - New: `threadDlCommand: dmPermission=false` ✅
  - New: `threadDlSpoilerCommand: dmPermission=false` ✅
  - New: `dlCommand + dlSpoilerCommand: dmPermission not set` ✅
- [ ] Real-environment verification: DM autocomplete suppression takes effect within ~1 hour of the bot restarting with the updated command registration

🤖 Generated with [Claude Code](https://claude.com/claude-code)