### PR TITLE
feat: mask Tweet URLs in matrix job names, show shard index in run numbers

### DIFF
--- a/.github/actions/check-and-convert-files/action.yml
+++ b/.github/actions/check-and-convert-files/action.yml
@@ -28,6 +28,10 @@ inputs:
     description: Command type for thread-download callbacks (omit or leave empty for non-thread)
     required: false
     default: ''
+  shard_index:
+    description: Zero-padded matrix shard index (e.g. "01"); forwarded to conv_progress.sh as SHARD_INDEX so the bot can render "#N-XX" run numbers. Omit for non-thread runs.
+    required: false
+    default: ''
 runs:
   using: composite
   steps:
@@ -42,6 +46,7 @@ runs:
         TOKEN: ${{ inputs.token }}
         LINK: ${{ inputs.link }}
         COMMAND_TYPE: ${{ inputs.command_type }}
+        SHARD_INDEX: ${{ inputs.shard_index }}
       run: |
         dir=$(pwd) && \
         cd download && \

--- a/.github/scripts/conv_progress.sh
+++ b/.github/scripts/conv_progress.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 # Read runtime values from environment variables set by the calling workflow step.
 # Required: ENDPOINT_URL, RUN_NUMBER, START_TIME, CHANNEL, MESSAGE, TOKEN, LINK
-# Optional: COMMAND_TYPE (set only for /threaddl and /threaddl-spoiler variants)
+# Optional: COMMAND_TYPE  (set only for /threaddl and /threaddl-spoiler variants)
+# Optional: SHARD_INDEX   (zero-padded matrix shard index, e.g. "01"; when set
+#                          the bot renders the run number as "#N-XX" in Discord)
 #
 # Positional arguments:
 #   $1 - progress log file path (monitored for changes)
@@ -11,6 +13,7 @@
 run_number="${RUN_NUMBER}"
 start_time="${START_TIME}"
 command_type="${COMMAND_TYPE:-}"
+shard_index="${SHARD_INDEX:-}"
 channel="${CHANNEL}"
 message="${MESSAGE}"
 token="${TOKEN}"
@@ -35,7 +38,9 @@ while true; do
       else
         :
       fi
-      if [[ -n "${command_type}" ]]; then
+      if [[ -n "${command_type}" && -n "${shard_index}" ]]; then
+        payload='{"status": "progress", "number": "'"${run_number}"'", "commandType": "'"${command_type}"'", "shardIndex": "'"${shard_index}"'", "startTime": "'"${start_time}"'", "channel": "'"${channel}"'", "message": "'"${message}"'", "token": "'"${token}"'", "link": "'"${link}"'", "content": "'"${4}(${2} / ${3})\n${progress}"'"}'
+      elif [[ -n "${command_type}" ]]; then
         payload='{"status": "progress", "number": "'"${run_number}"'", "commandType": "'"${command_type}"'", "startTime": "'"${start_time}"'", "channel": "'"${channel}"'", "message": "'"${message}"'", "token": "'"${token}"'", "link": "'"${link}"'", "content": "'"${4}(${2} / ${3})\n${progress}"'"}'
       else
         payload='{"status": "progress", "number": "'"${run_number}"'", "startTime": "'"${start_time}"'", "channel": "'"${channel}"'", "message": "'"${message}"'", "token": "'"${token}"'", "link": "'"${link}"'", "content": "'"${4}(${2} / ${3})\n${progress}"'"}'

--- a/.github/workflows/run-thread.yml
+++ b/.github/workflows/run-thread.yml
@@ -20,7 +20,7 @@ jobs:
           # Each item carries link + per-URL Discord message ID. The shared
           # thread channel ID, commandType, token and startTime are read from
           # the top-level event payload by every matrix shard.
-          matrix="$(jq -c '{include: [.client_payload.links[] | {link: .link, message: .message}]}' "${GITHUB_EVENT_PATH}")"
+          matrix="$(jq -c '{include: [.client_payload.links | to_entries[] | {index: ((.key + 1) | tostring | if length < 2 then ("0" + .) else . end), link: .value.link, message: .value.message}]}' "${GITHUB_EVENT_PATH}")"
           count="$(jq -r '.client_payload.links | length' "${GITHUB_EVENT_PATH}")"
           echo "matrix=${matrix}" >> "${GITHUB_OUTPUT}"
           echo "count=${count}" >> "${GITHUB_OUTPUT}"
@@ -28,7 +28,7 @@ jobs:
           echo "Count: ${count}"
 
   run-with-container:
-    name: Download (${{ matrix.link }})
+    name: Download #${{ matrix.index }}
     needs: [prepare]
     if: ${{ fromJson(needs.prepare.outputs.count) > 0 }}
     runs-on: ubuntu-latest
@@ -78,6 +78,7 @@ jobs:
             {
               "status": "progress",
               "number": ${{ github.run_number }},
+              "shardIndex": ${{ toJSON(matrix.index) }},
               "commandType": ${{ toJSON(github.event.client_payload.commandType) }},
               "startTime": ${{ toJSON(github.event.client_payload.startTime) }},
               "channel": ${{ toJSON(github.event.client_payload.channel) }},
@@ -105,6 +106,7 @@ jobs:
             {
               "status": "progress",
               "number": ${{ github.run_number }},
+              "shardIndex": ${{ toJSON(matrix.index) }},
               "commandType": ${{ toJSON(github.event.client_payload.commandType) }},
               "startTime": ${{ toJSON(github.event.client_payload.startTime) }},
               "channel": ${{ toJSON(github.event.client_payload.channel) }},
@@ -240,6 +242,7 @@ jobs:
             {
               "status": "progress",
               "number": ${{ github.run_number }},
+              "shardIndex": ${{ toJSON(matrix.index) }},
               "commandType": ${{ toJSON(github.event.client_payload.commandType) }},
               "startTime": ${{ toJSON(github.event.client_payload.startTime) }},
               "channel": ${{ toJSON(github.event.client_payload.channel) }},
@@ -364,6 +367,7 @@ jobs:
           endpoint_url: ${{ secrets.ENDPOINT_URL }}
           run_number: ${{ github.run_number }}
           command_type: ${{ github.event.client_payload.commandType }}
+          shard_index: ${{ matrix.index }}
           start_time: ${{ github.event.client_payload.startTime }}
           channel: ${{ github.event.client_payload.channel }}
           message: ${{ matrix.message }}
@@ -387,6 +391,7 @@ jobs:
             {
               "status": "progress",
               "number": ${{ github.run_number }},
+              "shardIndex": ${{ toJSON(matrix.index) }},
               "commandType": ${{ toJSON(github.event.client_payload.commandType) }},
               "startTime": ${{ toJSON(github.event.client_payload.startTime) }},
               "channel": ${{ toJSON(github.event.client_payload.channel) }},
@@ -416,6 +421,7 @@ jobs:
             options=()
             options+=(-F 'status=success')
             options+=(-F 'number=${{ github.run_number }}')
+            options+=(-F 'shardIndex=${{ matrix.index }}')
             options+=(-F 'commandType=${{ toJSON(github.event.client_payload.commandType) }}')
             options+=(-F 'actionType=thread-multi')
             options+=(-F 'channel=${{ toJSON(github.event.client_payload.channel) }}')
@@ -491,6 +497,7 @@ jobs:
                   --retry-all-errors \
                   -F "status=success" \
                   -F 'number=${{ github.run_number }}' \
+                  -F "shardIndex=${{ matrix.index }}" \
                   -F "commandType=${{ toJSON(github.event.client_payload.commandType) }}" \
                   -F "actionType=thread-single" \
                   -F "convert=false" \
@@ -573,6 +580,7 @@ jobs:
           {
             "status": "failure",
             "number": ${{ github.run_number }},
+            "shardIndex": ${{ toJSON(matrix.index) }},
             "commandType": ${{ toJSON(github.event.client_payload.commandType) }},
             "startTime": ${{ toJSON(github.event.client_payload.startTime) }},
             "channel": ${{ toJSON(github.event.client_payload.channel) }},
@@ -604,6 +612,7 @@ jobs:
           {
             "status": "failure",
             "number": ${{ github.run_number }},
+            "shardIndex": ${{ toJSON(matrix.index) }},
             "commandType": ${{ toJSON(github.event.client_payload.commandType) }},
             "startTime": ${{ toJSON(github.event.client_payload.startTime) }},
             "channel": ${{ toJSON(github.event.client_payload.channel) }},
@@ -648,6 +657,7 @@ jobs:
           {
             "status": "failure",
             "number": ${{ github.run_number }},
+            "shardIndex": ${{ toJSON(matrix.index) }},
             "commandType": ${{ toJSON(github.event.client_payload.commandType) }},
             "startTime": ${{ toJSON(github.event.client_payload.startTime) }},
             "channel": ${{ toJSON(github.event.client_payload.channel) }},
@@ -680,6 +690,7 @@ jobs:
           {
             "status": "failure",
             "number": ${{ github.run_number }},
+            "shardIndex": ${{ toJSON(matrix.index) }},
             "commandType": ${{ toJSON(github.event.client_payload.commandType) }},
             "startTime": ${{ toJSON(github.event.client_payload.startTime) }},
             "channel": ${{ toJSON(github.event.client_payload.channel) }},

--- a/src/router/functions/callbackFailureFunctions.ts
+++ b/src/router/functions/callbackFailureFunctions.ts
@@ -24,6 +24,11 @@ const callbackFailureFunctions: CallbackTypes.Functions.callbackFailure = {
     const useThread: boolean =
       infoObject.body!.commandType === threadDl ||
       infoObject.body!.commandType === threadDlSpoiler;
+    // Thread shards include a shardIndex field so the run number is shown
+    // as `#N-XX` (e.g. `#42-02`) in the Discord embed.
+    const runNumber: string = infoObject.body!.shardIndex
+      ? `${infoObject.body!.number}-${infoObject.body!.shardIndex}`
+      : infoObject.body!.number;
     // editMessage (thread mode) is not bound by the 15-min interaction-token
     // window, so always edit the placeholder when running in a thread.
     const isEditOriginalMessage: boolean =
@@ -37,7 +42,7 @@ const callbackFailureFunctions: CallbackTypes.Functions.callbackFailure = {
                 infoObject.body!.channel,
                 infoObject.body!.message,
                 Messages.createFailureMessage({
-                  runNumber: infoObject.body!.number,
+                  runNumber: runNumber,
                   runTime: runTime,
                   link: infoObject.body!.link,
                   content: infoObject.body!.content!,
@@ -47,7 +52,7 @@ const callbackFailureFunctions: CallbackTypes.Functions.callbackFailure = {
                 infoObject.body!.token,
                 infoObject.body!.message,
                 Messages.createFailureMessage({
-                  runNumber: infoObject.body!.number,
+                  runNumber: runNumber,
                   runTime: runTime,
                   link: infoObject.body!.link,
                   content: infoObject.body!.content!,
@@ -72,7 +77,7 @@ const callbackFailureFunctions: CallbackTypes.Functions.callbackFailure = {
               Messages.createFailureMessage({
                 messageId: infoObject.body!.message,
                 channelId: infoObject.body!.channel,
-                runNumber: infoObject.body!.number,
+                runNumber: runNumber,
                 runTime: runTime,
                 link: infoObject.body!.link,
                 content: infoObject.body!.content!,

--- a/src/router/functions/callbackProgressFunctions.ts
+++ b/src/router/functions/callbackProgressFunctions.ts
@@ -26,6 +26,11 @@ const callbackProgressFunctions: CallbackTypes.Functions.callbackProgress = {
     const useThread: boolean =
       infoObject.body!.commandType === threadDl ||
       infoObject.body!.commandType === threadDlSpoiler;
+    // Thread shards include a shardIndex field so the run number is shown
+    // as `#N-XX` (e.g. `#42-02`) in the Discord embed.
+    const runNumber: string = infoObject.body!.shardIndex
+      ? `${infoObject.body!.number}-${infoObject.body!.shardIndex}`
+      : infoObject.body!.number;
     // editMessage (thread mode) is not bound by the 15-min interaction-token
     // window, so always edit the placeholder when running in a thread.
     const isEditOriginalMessage: boolean =
@@ -39,7 +44,7 @@ const callbackProgressFunctions: CallbackTypes.Functions.callbackProgress = {
                 infoObject.body!.channel,
                 infoObject.body!.message,
                 Messages.createProgressMessage({
-                  runNumber: infoObject.body!.number,
+                  runNumber: runNumber,
                   runTime: runTime,
                   link: infoObject.body!.link,
                   content: infoObject.body!.content!,
@@ -49,7 +54,7 @@ const callbackProgressFunctions: CallbackTypes.Functions.callbackProgress = {
                 infoObject.body!.token,
                 infoObject.body!.message,
                 Messages.createProgressMessage({
-                  runNumber: infoObject.body!.number,
+                  runNumber: runNumber,
                   runTime: runTime,
                   link: infoObject.body!.link,
                   content: infoObject.body!.content!,

--- a/src/router/functions/callbackSuccessFunctions.ts
+++ b/src/router/functions/callbackSuccessFunctions.ts
@@ -19,6 +19,11 @@ const handleSingleSuccess = async <T extends string>(
 ): Promise<Response> => {
   if (!infoObject.body)
     return infoObject.c.body(null, { status: serverError });
+  // Thread shards include a shardIndex field so the run number is shown
+  // as `#N-XX` (e.g. `#42-02`) in the Discord embed.
+  const runNumber: string = infoObject.body.shardIndex
+    ? `${infoObject.body.number}-${infoObject.body.shardIndex}`
+    : infoObject.body.number;
   let filesObject = await Contents.singleFileContent(infoObject.body)
     .then((i) => i)
     .catch(() => null);
@@ -30,7 +35,7 @@ const handleSingleSuccess = async <T extends string>(
         token: infoObject.body.token,
         channelId: infoObject.body.channel,
         messageId: infoObject.body.message,
-        runNumber: infoObject.body.number,
+        runNumber: runNumber,
         startTime: infoObject.body.startTime,
         totalSize: infoObject.body.size!,
         fileName: filesObject.fileName,
@@ -51,7 +56,7 @@ const handleSingleSuccess = async <T extends string>(
       token: infoObject.body.token,
       channel: infoObject.body.channel,
       message: infoObject.body.message,
-      number: infoObject.body.number,
+      number: runNumber,
       link: infoObject.body.link,
       description: (e as Error).message,
       startTime: infoObject.body.startTime,
@@ -82,6 +87,11 @@ const handleMultiSuccess = async <T extends string>(
 ): Promise<Response> => {
   if (!infoObject.body)
     return infoObject.c.body(null, { status: serverError });
+  // Thread shards include a shardIndex field so the run number is shown
+  // as `#N-XX` (e.g. `#42-02`) in the Discord embed.
+  const runNumber: string = infoObject.body.shardIndex
+    ? `${infoObject.body.number}-${infoObject.body.shardIndex}`
+    : infoObject.body.number;
   let multiFilesObject = await Contents.multiFilesContent(infoObject.body)
     .then((i) => i)
     .catch(() => null);
@@ -93,7 +103,7 @@ const handleMultiSuccess = async <T extends string>(
         token: infoObject.body.token,
         channelId: infoObject.body.channel,
         messageId: infoObject.body.message,
-        runNumber: infoObject.body.number,
+        runNumber: runNumber,
         startTime: infoObject.body.startTime,
         totalSize: infoObject.body.size!,
         fileNamesArray: multiFilesObject.fileNamesArray,
@@ -114,7 +124,7 @@ const handleMultiSuccess = async <T extends string>(
       token: infoObject.body.token,
       channel: infoObject.body.channel,
       message: infoObject.body.message,
-      number: infoObject.body.number,
+      number: runNumber,
       link: infoObject.body.link,
       description: (e as Error).message,
       startTime: infoObject.body.startTime,

--- a/src/router/types/callbackTypes.ts
+++ b/src/router/types/callbackTypes.ts
@@ -12,6 +12,7 @@ export namespace CallbackTypes {
     message: string;
     token: string;
     link: string;
+    shardIndex?: string;
     convert?: "true" | "false";
     oversize?: "true" | "false";
     name1?: string;

--- a/tests/router/functions/callbackFailureFunctions.test.ts
+++ b/tests/router/functions/callbackFailureFunctions.test.ts
@@ -228,7 +228,52 @@ Deno.test("callbackFailureFunctions.failure", async (t) => {
     },
   );
 
-  // ── Case 6: editMessage rejects → 500 ──
+  // ── Case 6 (shardIndex): threaddl + shardIndex → run number is "#N-XX" ──
+  await t.step(
+    "threaddl + shardIndex=03 → editMessage called with runNumber '2-03'",
+    async () => {
+      let capturedArg: unknown;
+      const editMsg = stub(
+        bot.helpers,
+        "editMessage",
+        (_ch: unknown, _msg: unknown, payload: unknown) => {
+          capturedArg = payload;
+          return Promise.resolve(fakeMsg);
+        },
+      );
+      const editFollowup = stub(
+        bot.helpers,
+        "editFollowupMessage",
+        () => Promise.resolve(fakeMsg),
+      );
+      const sendMsg = stub(
+        bot.helpers,
+        "sendMessage",
+        () => Promise.resolve(fakeMsg),
+      );
+      try {
+        const body = { ...makeBody("threaddl"), shardIndex: "03" };
+        const res = await callbackFailureFunctions.failure({
+          c: makeCtx() as never,
+          body,
+        });
+        assertEquals(res.status, 204);
+        assertSpyCalls(editMsg, 1);
+        assertSpyCalls(editFollowup, 0);
+        assertSpyCalls(sendMsg, 0);
+        const embed = (capturedArg as { embeds?: { fields?: { value: string }[] }[] })
+          ?.embeds?.[0];
+        const runField = embed?.fields?.find((f) => f.value.includes("2-03"));
+        assertEquals(runField !== undefined, true);
+      } finally {
+        editMsg.restore();
+        editFollowup.restore();
+        sendMsg.restore();
+      }
+    },
+  );
+
+  // ── Case 7: editMessage rejects → 500 ──
   await t.step(
     "editMessage rejects → returns 500",
     async () => {

--- a/tests/router/functions/callbackProgressFunctions.test.ts
+++ b/tests/router/functions/callbackProgressFunctions.test.ts
@@ -221,7 +221,83 @@ Deno.test("callbackProgressFunctions.progress", async (t) => {
     },
   );
 
-  // ── Case 7: editFollowupMessage rejects → 500 ──
+  // ── Case 7 (shardIndex): threaddl + shardIndex → run number is "#N-XX" ──
+  await t.step(
+    "threaddl + shardIndex=02 → editMessage called with runNumber '1-02'",
+    async () => {
+      let capturedArg: unknown;
+      const editMsg = stub(
+        bot.helpers,
+        "editMessage",
+        (_ch, _msg, payload) => {
+          capturedArg = payload;
+          return Promise.resolve(fakeMsg);
+        },
+      );
+      const editFollowup = stub(
+        bot.helpers,
+        "editFollowupMessage",
+        () => Promise.resolve(fakeMsg),
+      );
+      try {
+        const body = { ...makeBody("threaddl"), shardIndex: "02" };
+        const res = await callbackProgressFunctions.progress({
+          c: makeCtx() as never,
+          body,
+        });
+        assertEquals(res.status, 204);
+        assertSpyCalls(editMsg, 1);
+        assertSpyCalls(editFollowup, 0);
+        // The embed field value for RUN_NUMBER should contain "1-02"
+        const embed = (capturedArg as { embeds?: { fields?: { value: string }[] }[] })
+          ?.embeds?.[0];
+        const runField = embed?.fields?.find((f) => f.value.includes("1-02"));
+        assertEquals(runField !== undefined, true);
+      } finally {
+        editMsg.restore();
+        editFollowup.restore();
+      }
+    },
+  );
+
+  // ── Case 7b: dl without shardIndex → run number stays plain "#N" ──
+  await t.step(
+    "dl without shardIndex → editFollowupMessage called with plain runNumber '1'",
+    async () => {
+      let capturedArg: unknown;
+      const editMsg = stub(
+        bot.helpers,
+        "editMessage",
+        () => Promise.resolve(fakeMsg),
+      );
+      const editFollowup = stub(
+        bot.helpers,
+        "editFollowupMessage",
+        (_tok, _msg, payload) => {
+          capturedArg = payload;
+          return Promise.resolve(fakeMsg);
+        },
+      );
+      try {
+        const res = await callbackProgressFunctions.progress({
+          c: makeCtx() as never,
+          body: makeBody("dl"),
+        });
+        assertEquals(res.status, 204);
+        assertSpyCalls(editFollowup, 1);
+        const embed = (capturedArg as { embeds?: { fields?: { value: string }[] }[] })
+          ?.embeds?.[0];
+        // value should be `> \`#1\`` — no dash
+        const runField = embed?.fields?.find((f) => f.value === "> `#1`");
+        assertEquals(runField !== undefined, true);
+      } finally {
+        editMsg.restore();
+        editFollowup.restore();
+      }
+    },
+  );
+
+  // ── Case 8: editFollowupMessage rejects → 500 ──
   await t.step(
     "editFollowupMessage rejects → returns 500",
     async () => {

--- a/tests/router/functions/callbackSuccessFunctions.test.ts
+++ b/tests/router/functions/callbackSuccessFunctions.test.ts
@@ -1,0 +1,331 @@
+import { assertEquals } from "@std/assert";
+import { assertSpyCalls, stub } from "@std/testing/mock";
+import type { Message } from "discordeno";
+import bot from "../../../src/bot/bot.ts";
+import callbackSuccessFunctions from "../../../src/router/functions/callbackSuccessFunctions.ts";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const fakeMsg = {} as unknown as Message;
+
+/** Minimal Hono Context stub — only the `body()` method is needed. */
+const makeCtx = () => ({
+  body(_data: BodyInit | null, init?: { status: number } | number): Response {
+    const status =
+      typeof init === "number"
+        ? init
+        : ((init as { status: number } | undefined)?.status ?? 200);
+    return new Response(null, { status });
+  },
+});
+
+type CommandType = "dl" | "dl-spoiler" | "threaddl" | "threaddl-spoiler";
+
+/** Build a minimal body with file1+name1 for single-file success. */
+function makeBody(
+  commandType: CommandType = "dl",
+  extra: Record<string, unknown> = {},
+) {
+  return {
+    status: "success" as const,
+    number: "1",
+    commandType,
+    startTime: String(Date.now() - 1_000), // 1s ago — well within time limit
+    channel: "111222333",
+    message: "444555666",
+    token: "fake-token",
+    link: "https://example.com/status/1",
+    type: "video",
+    size: "1024",
+    oversize: "false" as const,
+    file1: new File(["video-data"], "test.mp4", { type: "video/mp4" }),
+    name1: "test.mp4",
+    ...extra,
+  };
+}
+
+/** Build a minimal body with file1+name1+file2+name2 for multi-file success. */
+function makeMultiBody(
+  commandType: CommandType = "dl",
+  extra: Record<string, unknown> = {},
+) {
+  return {
+    ...makeBody(commandType, extra),
+    file2: new File(["video-data-2"], "test2.mp4", { type: "video/mp4" }),
+    name2: "test2.mp4",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+Deno.test("callbackSuccessFunctions — handleSingleSuccess", async (t) => {
+  // ── Case 1: dl (useThread=false, short runTime) → editFollowupMessage ──
+  await t.step(
+    "dl + no shardIndex → editFollowupMessage called, returns 204",
+    async () => {
+      const editMsg = stub(
+        bot.helpers,
+        "editMessage",
+        () => Promise.resolve(fakeMsg),
+      );
+      const editFollowup = stub(
+        bot.helpers,
+        "editFollowupMessage",
+        () => Promise.resolve(fakeMsg),
+      );
+      try {
+        const res = await callbackSuccessFunctions.success.dl.single({
+          c: makeCtx() as never,
+          body: makeBody("dl") as never,
+        });
+        assertEquals(res.status, 204);
+        assertSpyCalls(editFollowup, 1);
+        assertSpyCalls(editMsg, 0);
+      } finally {
+        editMsg.restore();
+        editFollowup.restore();
+      }
+    },
+  );
+
+  // ── Case 2: threadDl (useThread=true) → editMessage ──
+  await t.step(
+    "threadDl + no shardIndex → editMessage called, returns 204",
+    async () => {
+      const editMsg = stub(
+        bot.helpers,
+        "editMessage",
+        () => Promise.resolve(fakeMsg),
+      );
+      const editFollowup = stub(
+        bot.helpers,
+        "editFollowupMessage",
+        () => Promise.resolve(fakeMsg),
+      );
+      try {
+        const res = await callbackSuccessFunctions.success.threadDl.single({
+          c: makeCtx() as never,
+          body: makeBody("threaddl") as never,
+        });
+        assertEquals(res.status, 204);
+        assertSpyCalls(editMsg, 1);
+        assertSpyCalls(editFollowup, 0);
+      } finally {
+        editMsg.restore();
+        editFollowup.restore();
+      }
+    },
+  );
+
+  // ── Case 3: threadDl + shardIndex → runNumber is "#N-XX" in embed ──
+  await t.step(
+    "threadDl + shardIndex=02 → editMessage called with runNumber '1-02' in embed",
+    async () => {
+      let capturedPayload: unknown;
+      const editMsg = stub(
+        bot.helpers,
+        "editMessage",
+        (_ch, _msg, payload) => {
+          capturedPayload = payload;
+          return Promise.resolve(fakeMsg);
+        },
+      );
+      const editFollowup = stub(
+        bot.helpers,
+        "editFollowupMessage",
+        () => Promise.resolve(fakeMsg),
+      );
+      try {
+        const res = await callbackSuccessFunctions.success.threadDl.single({
+          c: makeCtx() as never,
+          body: makeBody("threaddl", { shardIndex: "02" }) as never,
+        });
+        assertEquals(res.status, 204);
+        assertSpyCalls(editMsg, 1);
+        // The RUN_NUMBER embed field should contain "1-02"
+        const embed = (
+          capturedPayload as { embeds?: { fields?: { value: string }[] }[] }
+        )?.embeds?.[0];
+        const runField = embed?.fields?.find((f) => f.value.includes("1-02"));
+        assertEquals(runField !== undefined, true);
+      } finally {
+        editMsg.restore();
+        editFollowup.restore();
+      }
+    },
+  );
+
+  // ── Case 4: dl + no shardIndex → runNumber is plain "#N" ──
+  await t.step(
+    "dl + no shardIndex → editFollowupMessage called with plain runNumber '1'",
+    async () => {
+      let capturedPayload: unknown;
+      const editMsg = stub(
+        bot.helpers,
+        "editMessage",
+        () => Promise.resolve(fakeMsg),
+      );
+      const editFollowup = stub(
+        bot.helpers,
+        "editFollowupMessage",
+        (_tok, _msg, payload) => {
+          capturedPayload = payload;
+          return Promise.resolve(fakeMsg);
+        },
+      );
+      try {
+        const res = await callbackSuccessFunctions.success.dl.single({
+          c: makeCtx() as never,
+          body: makeBody("dl") as never,
+        });
+        assertEquals(res.status, 204);
+        assertSpyCalls(editFollowup, 1);
+        // The RUN_NUMBER embed field value should be `> \`#1\`` with no dash
+        const embed = (
+          capturedPayload as { embeds?: { fields?: { value: string }[] }[] }
+        )?.embeds?.[0];
+        const runField = embed?.fields?.find((f) => f.value === "> `#1`");
+        assertEquals(runField !== undefined, true);
+      } finally {
+        editMsg.restore();
+        editFollowup.restore();
+      }
+    },
+  );
+
+  // ── Case 5: null body → 500 immediately ──
+  await t.step("null body → returns 500 without calling Discord helpers", async () => {
+    const editMsg = stub(
+      bot.helpers,
+      "editMessage",
+      () => Promise.resolve(fakeMsg),
+    );
+    const editFollowup = stub(
+      bot.helpers,
+      "editFollowupMessage",
+      () => Promise.resolve(fakeMsg),
+    );
+    try {
+      const res = await callbackSuccessFunctions.success.dl.single({
+        c: makeCtx() as never,
+        body: null,
+      });
+      assertEquals(res.status, 500);
+      assertSpyCalls(editMsg, 0);
+      assertSpyCalls(editFollowup, 0);
+    } finally {
+      editMsg.restore();
+      editFollowup.restore();
+    }
+  });
+
+  // ── Case 6: threadDlSpoiler + shardIndex → editMessage (spoiler+thread) ──
+  await t.step(
+    "threadDlSpoiler + shardIndex=03 → editMessage called with '1-03' in embed",
+    async () => {
+      let capturedPayload: unknown;
+      const editMsg = stub(
+        bot.helpers,
+        "editMessage",
+        (_ch, _msg, payload) => {
+          capturedPayload = payload;
+          return Promise.resolve(fakeMsg);
+        },
+      );
+      const editFollowup = stub(
+        bot.helpers,
+        "editFollowupMessage",
+        () => Promise.resolve(fakeMsg),
+      );
+      try {
+        const res =
+          await callbackSuccessFunctions.success.threadDlSpoiler.single({
+            c: makeCtx() as never,
+            body: makeBody("threaddl-spoiler", { shardIndex: "03" }) as never,
+          });
+        assertEquals(res.status, 204);
+        assertSpyCalls(editMsg, 1);
+        const embed = (
+          capturedPayload as { embeds?: { fields?: { value: string }[] }[] }
+        )?.embeds?.[0];
+        const runField = embed?.fields?.find((f) => f.value.includes("1-03"));
+        assertEquals(runField !== undefined, true);
+      } finally {
+        editMsg.restore();
+        editFollowup.restore();
+      }
+    },
+  );
+});
+
+Deno.test("callbackSuccessFunctions — handleMultiSuccess", async (t) => {
+  // ── Case 7: dl multi (useThread=false) → editFollowupMessage ──
+  await t.step(
+    "dl.multi + no shardIndex → editFollowupMessage called, returns 204",
+    async () => {
+      const editMsg = stub(
+        bot.helpers,
+        "editMessage",
+        () => Promise.resolve(fakeMsg),
+      );
+      const editFollowup = stub(
+        bot.helpers,
+        "editFollowupMessage",
+        () => Promise.resolve(fakeMsg),
+      );
+      try {
+        const res = await callbackSuccessFunctions.success.dl.multi({
+          c: makeCtx() as never,
+          body: makeMultiBody("dl") as never,
+        });
+        assertEquals(res.status, 204);
+        assertSpyCalls(editFollowup, 1);
+        assertSpyCalls(editMsg, 0);
+      } finally {
+        editMsg.restore();
+        editFollowup.restore();
+      }
+    },
+  );
+
+  // ── Case 8: threadDl multi + shardIndex → editMessage with "#N-XX" ──
+  await t.step(
+    "threadDl.multi + shardIndex=01 → editMessage called with '1-01' in embed",
+    async () => {
+      let capturedPayload: unknown;
+      const editMsg = stub(
+        bot.helpers,
+        "editMessage",
+        (_ch, _msg, payload) => {
+          capturedPayload = payload;
+          return Promise.resolve(fakeMsg);
+        },
+      );
+      const editFollowup = stub(
+        bot.helpers,
+        "editFollowupMessage",
+        () => Promise.resolve(fakeMsg),
+      );
+      try {
+        const res = await callbackSuccessFunctions.success.threadDl.multi({
+          c: makeCtx() as never,
+          body: makeMultiBody("threaddl", { shardIndex: "01" }) as never,
+        });
+        assertEquals(res.status, 204);
+        assertSpyCalls(editMsg, 1);
+        const embed = (
+          capturedPayload as { embeds?: { fields?: { value: string }[] }[] }
+        )?.embeds?.[0];
+        const runField = embed?.fields?.find((f) => f.value.includes("1-01"));
+        assertEquals(runField !== undefined, true);
+      } finally {
+        editMsg.restore();
+        editFollowup.restore();
+      }
+    },
+  );
+});

--- a/tests/scripts/conv_progress.test.ts
+++ b/tests/scripts/conv_progress.test.ts
@@ -70,6 +70,7 @@ interface RunOpts {
   totalFiles?: string;
   phase?: string;
   commandType?: string;
+  shardIndex?: string;
 }
 
 /** Start conv_progress.sh in background. Returns kill handle. */
@@ -80,6 +81,7 @@ function startScript(opts: RunOpts): Deno.ChildProcess {
     PATH: Deno.env.get("PATH") ?? "/usr/bin:/bin",
   };
   if (opts.commandType !== undefined) env.COMMAND_TYPE = opts.commandType;
+  if (opts.shardIndex !== undefined) env.SHARD_INDEX = opts.shardIndex;
 
   const cmd = new Deno.Command("bash", {
     args: [
@@ -239,6 +241,73 @@ Deno.test("conv_progress.sh", async (t) => {
         assertEquals(json.startTime, "1000000");
         assertEquals(json.message, "444555666");
         assertEquals(json.number, "42");
+      } finally {
+        proc.kill("SIGKILL");
+        await proc.status.catch(() => {});
+        srv.close();
+        await Deno.remove(tmpDir, { recursive: true });
+      }
+    },
+  );
+
+  // ── Case 5: SHARD_INDEX + COMMAND_TYPE → shardIndex field in payload ──
+  await t.step(
+    "with COMMAND_TYPE=threaddl and SHARD_INDEX=02 → shardIndex field present",
+    async () => {
+      const tmpDir = await Deno.makeTempDir();
+      const progressFile = `${tmpDir}/progress.log`;
+      await Deno.writeTextFile(progressFile, "initial");
+
+      const srv = await makeCaptureSrv();
+      const proc = startScript({
+        url: srv.url,
+        progressFile,
+        commandType: "threaddl",
+        shardIndex: "02",
+      });
+
+      try {
+        await new Promise((r) => setTimeout(r, 1200));
+        await Deno.writeTextFile(progressFile, "00:00:03/00:01:00(3%)");
+
+        const body = await withTimeout(srv.bodyPromise, 10_000);
+        const json = JSON.parse(body);
+
+        assertEquals(json.commandType, "threaddl");
+        assertEquals(json.shardIndex, "02");
+        assertEquals(json.number, "42");
+      } finally {
+        proc.kill("SIGKILL");
+        await proc.status.catch(() => {});
+        srv.close();
+        await Deno.remove(tmpDir, { recursive: true });
+      }
+    },
+  );
+
+  // ── Case 6: SHARD_INDEX without COMMAND_TYPE → shardIndex omitted ──
+  await t.step(
+    "without COMMAND_TYPE but with SHARD_INDEX → shardIndex omitted (non-thread path)",
+    async () => {
+      const tmpDir = await Deno.makeTempDir();
+      const progressFile = `${tmpDir}/progress.log`;
+      await Deno.writeTextFile(progressFile, "initial");
+
+      const srv = await makeCaptureSrv();
+      // No commandType means non-thread workflow — SHARD_INDEX is never set
+      // for those runs, but guard that the script still behaves correctly when
+      // only one of the two is absent.
+      const proc = startScript({ url: srv.url, progressFile });
+
+      try {
+        await new Promise((r) => setTimeout(r, 1200));
+        await Deno.writeTextFile(progressFile, "00:00:04/00:01:00(4%)");
+
+        const body = await withTimeout(srv.bodyPromise, 10_000);
+        const json = JSON.parse(body);
+
+        assertEquals("commandType" in json, false);
+        assertEquals("shardIndex" in json, false);
       } finally {
         proc.kill("SIGKILL");
         await proc.status.catch(() => {});

--- a/tests/scripts/conv_progress.test.ts
+++ b/tests/scripts/conv_progress.test.ts
@@ -294,10 +294,9 @@ Deno.test("conv_progress.sh", async (t) => {
       await Deno.writeTextFile(progressFile, "initial");
 
       const srv = await makeCaptureSrv();
-      // No commandType means non-thread workflow — SHARD_INDEX is never set
-      // for those runs, but guard that the script still behaves correctly when
-      // only one of the two is absent.
-      const proc = startScript({ url: srv.url, progressFile });
+      // SHARD_INDEX is set but COMMAND_TYPE is absent (non-thread path).
+      // The script omits both fields from the payload in this case.
+      const proc = startScript({ url: srv.url, progressFile, shardIndex: "02" });
 
       try {
         await new Promise((r) => setTimeout(r, 1200));


### PR DESCRIPTION
## Summary

- **Matrix URL masking**: `run-thread.yml` now generates a zero-padded `index` field (`01`, `02`, …) in the `jq` matrix build step. Each download job is renamed to `Download #${{ matrix.index }}` so no Tweet URL ever appears in a GitHub Actions job name. (`::add-mask::` cannot intercept matrix variable expansions, making index-based naming the only reliable solution.)
- **Shard index in Discord embeds**: The `shardIndex` value is propagated through the full callback pipeline — `conv_progress.sh` reads `SHARD_INDEX` env and includes it in the JSON payload; the bot (`callbackProgressFunctions`, `callbackFailureFunctions`, `callbackSuccessFunctions`) formats the run number as `#N-XX` when `shardIndex` is present, or plain `#N` for non-thread runs.
- **Composite action**: `check-and-convert-files/action.yml` gains a `shard_index` input forwarded as `SHARD_INDEX` env to `conv_progress.sh`.

## Changed files

| File | Change |
|---|---|
| `.github/workflows/run-thread.yml` | matrix index generation, job rename, `shardIndex` in all payloads |
| `.github/scripts/conv_progress.sh` | `SHARD_INDEX` env → 3-branch JSON payload |
| `.github/actions/check-and-convert-files/action.yml` | `shard_index` input + `SHARD_INDEX` env |
| `src/router/types/callbackTypes.ts` | `shardIndex?: string` field |
| `src/router/functions/callbackProgressFunctions.ts` | `runNumber` formatting (`#N-XX` / `#N`) |
| `src/router/functions/callbackFailureFunctions.ts` | same |
| `src/router/functions/callbackSuccessFunctions.ts` | same |

## Test plan

- [x] `tests/scripts/conv_progress.test.ts`: 2 new cases — SHARD_INDEX present → `shardIndex` in payload; absent → field omitted
- [x] `tests/router/functions/callbackProgressFunctions.test.ts`: 2 new cases — `threaddl + shardIndex=02` → embed contains `1-02`; `dl` no shardIndex → embed field is `` > `#1` ``
- [x] `tests/router/functions/callbackFailureFunctions.test.ts`: 1 new case — `threaddl + shardIndex=03` → embed contains `2-03`
- [x] Full test suite: `ok | 26 passed (134 steps) | 0 failed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)