### PR TITLE
fix(ci): quote job name to prevent YAML '#' comment stripping URL mask

### DIFF
--- a/.github/workflows/run-thread.yml
+++ b/.github/workflows/run-thread.yml
@@ -28,7 +28,7 @@ jobs:
           echo "Count: ${count}"
 
   run-with-container:
-    name: Download #${{ matrix.index }}
+    name: 'Download #${{ matrix.index }}'
     needs: [prepare]
     if: ${{ fromJson(needs.prepare.outputs.count) > 0 }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
## 問題

PR #25 で追加した以下の job name が **YAML パーサにコメント扱い**されていた:

```yaml
name: Download #${{ matrix.index }}
```

YAML 仕様では、**空白に続く `#`** はコメント開始と解釈される。そのため YAML パーサは値を `Download` で打ち切り、`#${{ matrix.index }}` 以降を破棄する。

GitHub Actions は job name が設定されていない（または不完全な）場合、**matrix の全タプルを自動付与**するため:

```
Before fix → Download (02, https://x.com/.../status/...?s=46&t=..., 1503...)
After fix  → Download #02
```

`::add-mask::` は matrix expansion による job name には効かないため、URL が workflow run ページに露出していた（PR #25 の URL マスク対策が無効化されていた）。

## 修正

```diff
-    name: Download #${{ matrix.index }}
+    name: 'Download #${{ matrix.index }}'
```

シングルクォートで囲むことで `#` がリテラル文字として扱われ、意図どおり `Download #01` などの job 名が表示される。

## 確認

- `grep -n 'name:.*#' .github/workflows/*.yml` — 他 workflow に同パターンなし（`run-thread.yml` の 1 箇所のみ）
- Bot 側コード変更なし
- 既存テスト全 pass（変更は YAML 1 行のみ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)