### PR TITLE
fix(ci): add missing shardIndex to 3 progress callbacks

### DIFF
--- a/.github/workflows/run-thread.yml
+++ b/.github/workflows/run-thread.yml
@@ -166,6 +166,7 @@ jobs:
               {
                 "status": "progress",
                 "number": ${{ github.run_number }},
+                "shardIndex": ${{ toJSON(matrix.index) }},
                 "commandType": ${{ toJSON(github.event.client_payload.commandType) }},
                 "startTime": ${{ toJSON(github.event.client_payload.startTime) }},
                 "channel": ${{ toJSON(github.event.client_payload.channel) }},
@@ -194,6 +195,7 @@ jobs:
                   {
                     "status": "progress",
                     "number": ${{ github.run_number }},
+                    "shardIndex": ${{ toJSON(matrix.index) }},
                     "commandType": ${{ toJSON(github.event.client_payload.commandType) }},
                     "startTime": ${{ toJSON(github.event.client_payload.startTime) }},
                     "channel": ${{ toJSON(github.event.client_payload.channel) }},
@@ -278,6 +280,7 @@ jobs:
                 {
                   "status": "progress",
                   "number": ${{ github.run_number }},
+                  "shardIndex": ${{ toJSON(matrix.index) }},
                   "commandType": ${{ toJSON(github.event.client_payload.commandType) }},
                   "startTime": ${{ toJSON(github.event.client_payload.startTime) }},
                   "channel": ${{ toJSON(github.event.client_payload.channel) }},


### PR DESCRIPTION
## 問題

PR #25 で `shardIndex` を全 callback に追加したつもりだったが、3 箇所の progress payload で漏れが発生していた。これらは retry loop 内の進捗通知で、エラー直前にユーザーが最後に見るメッセージになることが多い。

**漏れていた 3 箇所:**

| 箇所 | content |
|---|---|
| Link チェック（初回） | `🔍Checking link status...` |
| Link チェック（retry N） | `🔍Checking link status...(Retry N / 1000)` |
| Download（retry N） | `⏬Downloading...(Retry N / 1000)` |

これらが `shardIndex` を持たないと bot 側で `#N` と表示され、他の shard が `#N-XX` を表示しているのと混在する問題が起きていた。

## 修正

各 JSON ペイロードの `"number"` の直後に `"shardIndex": ${{ toJSON(matrix.index) }},` を追加:

```diff
  "status": "progress",
  "number": ${{ github.run_number }},
+ "shardIndex": ${{ toJSON(matrix.index) }},
  "commandType": ${{ toJSON(github.event.client_payload.commandType) }},
```

3 箇所とも同一の修正パターン（インデント幅のみ異なる）。

## 確認

```
grep -c '"shardIndex"' .github/workflows/run-thread.yml
# Before: 8
# After:  11
```

全 11 の status callback（progress 7 + failure 4）が `shardIndex` を持つ状態になり、PR #25 の意図が完成する。

Bot 側コード変更なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)