### PR TITLE
fix(ci): add missing shardIndex to single-file convert success callback

### DIFF
--- a/.github/workflows/run-thread.yml
+++ b/.github/workflows/run-thread.yml
@@ -536,6 +536,7 @@ jobs:
                     --retry-all-errors \
                     -F "status=success" \
                     -F 'number=${{ github.run_number }}' \
+                    -F "shardIndex=${{ matrix.index }}" \
                     -F "commandType=${{ toJSON(github.event.client_payload.commandType) }}" \
                     -F "actionType=thread-single" \
                     -F "convert=true" \


### PR DESCRIPTION
## 問題

PR #25 で `shardIndex` を全 success callback に追加した想定だったが、**single-file with convert** (`convert=true`, `thread-single`) の multipart POST だけ漏れていた。

3 つの success path の状況:

| path | shardIndex | 行 |
|---|---|---|
| multi-file (`options+=`) | ✓ | 427 |
| single-file no-convert | ✓ | 503 |
| **single-file with convert** | **❌** | **537** |

ほとんどの動画は 10MB 超で再エンコード必須 → **convert=true path が primary success path**。このパスで `shardIndex` が欠けていたため、success embed で `#N` と `#N-XX` が混在する問題が発生していた。

## 修正

```diff
                    -F 'number=${{ github.run_number }}' \
+                   -F "shardIndex=${{ matrix.index }}" \
                    -F "commandType=${{ toJSON(github.event.client_payload.commandType) }}" \
```

`number` の直後に 1 行追加。他 2 path と同一パターン。Bot 側コード変更なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)