### PR TITLE
fix(bot): attach files in thread success via manual multipart PATCH

### DIFF
--- a/src/router/messages/successMessage.ts
+++ b/src/router/messages/successMessage.ts
@@ -1,6 +1,7 @@
 import bot from "@bot/bot.ts";
 import { Match } from "functional";
-import { Message, EditMessage } from "discordeno";
+import { Message, Embed } from "discordeno";
+import type { FileContent, CreateMessage } from "discordeno";
 import { Messages, Constants } from "@libs";
 import { CreateMessageTypes } from "@router/types/createMessageTypes.ts";
 
@@ -11,6 +12,53 @@ type MultiSuccsessMessageObject =
 
 const trueOversize = Constants.CallbackObject.Oversize.TRUE;
 const editFollowupMessageTimeLimit = Constants.EDIT_FOLLOWUP_MESSAGE_TIME_LIMIT;
+
+/**
+ * Edits a thread placeholder message with an embed and file attachments via
+ * direct multipart PATCH.
+ *
+ * **Why not `bot.helpers.editMessage`?**
+ * discordeno v18's `editMessage` helper builds the multipart body in
+ * `createRequestBody.ts` as:
+ * ```
+ * form.append("payload_json", JSON.stringify({ ...body, file: undefined }));
+ * ```
+ * It spreads the body but does **not** inject an `attachments` array.
+ * Discord's PATCH /channels/{id}/messages/{id} endpoint (updated 2022)
+ * requires new file attachments to be referenced by zero-based index in
+ * `payload_json.attachments`; without this, file data arrives at Discord
+ * but is silently discarded.
+ *
+ * This function calls `bot.rest.runMethod` directly so we can add the
+ * correct `attachments: [{id: N, filename}]` entries.  If a future
+ * discordeno release fixes the upstream behaviour, revert to
+ * `bot.helpers.editMessage`.
+ */
+async function editThreadMessageWithFiles(
+  channelId: bigint | string,
+  messageId: bigint | string,
+  content: string | null | undefined,
+  embeds: Embed[],
+  files: FileContent[],
+): Promise<Message> {
+  const result = await bot.rest.runMethod<Record<string, unknown>>(
+    bot.rest,
+    "PATCH",
+    bot.constants.routes.CHANNEL_MESSAGE(channelId, messageId),
+    {
+      content,
+      embeds: embeds.map((e) => bot.transformers.reverse.embed(bot, e)),
+      file: files.length === 1 ? files[0] : files,
+      // Discord API (2022+): multipart PATCH requires `attachments[].id` in
+      // payload_json to reference each uploaded file by its zero-based index
+      // in the `files[N]` parts.  Without this, Discord ignores the files.
+      attachments: files.map((f, i) => ({ id: i, filename: f.name })),
+    },
+  );
+  // Callers chain .then()/.catch() on the Promise but never use the Message
+  // value directly, so casting the raw response is safe here.
+  return result as unknown as Message;
+}
 
 const successMessage = {
   /**
@@ -35,38 +83,49 @@ const successMessage = {
     return Match(isEditOriginalMessage)
       .with(
         true,
-        async (): Promise<Message> =>
-          useThread
-            ? await bot.helpers
-                .editMessage(
-                  singleSuccsessMessageObject!.channelId,
-                  singleSuccsessMessageObject!.messageId,
-                  Messages.createSuccessMessage({
-                    runNumber: singleSuccsessMessageObject!.runNumber,
-                    runTime: runTime,
-                    totalSize: singleSuccsessMessageObject!.totalSize,
-                    fileName: singleSuccsessMessageObject!.fileName,
-                    link: singleSuccsessMessageObject!.link,
-                    file: singleSuccsessMessageObject!.file,
-                    spoiler: singleSuccsessMessageObject!.spoiler,
-                  }) as EditMessage,
-                )
-                .finally((): null => (singleSuccsessMessageObject = null))
-            : await bot.helpers
-                .editFollowupMessage(
-                  singleSuccsessMessageObject!.token,
-                  singleSuccsessMessageObject!.messageId,
-                  Messages.createSuccessMessage({
-                    runNumber: singleSuccsessMessageObject!.runNumber,
-                    runTime: runTime,
-                    totalSize: singleSuccsessMessageObject!.totalSize,
-                    fileName: singleSuccsessMessageObject!.fileName,
-                    link: singleSuccsessMessageObject!.link,
-                    file: singleSuccsessMessageObject!.file,
-                    spoiler: singleSuccsessMessageObject!.spoiler,
-                  }),
-                )
-                .finally((): null => (singleSuccsessMessageObject = null)),
+        async (): Promise<Message> => {
+          if (useThread) {
+            // Thread mode: use manual multipart PATCH to include `attachments`
+            // in payload_json (discordeno v18 omits this — see JSDoc above).
+            const msgPayload = Messages.createSuccessMessage({
+              runNumber: singleSuccsessMessageObject!.runNumber,
+              runTime: runTime,
+              totalSize: singleSuccsessMessageObject!.totalSize,
+              fileName: singleSuccsessMessageObject!.fileName,
+              link: singleSuccsessMessageObject!.link,
+              file: singleSuccsessMessageObject!.file,
+              spoiler: singleSuccsessMessageObject!.spoiler,
+            }) as CreateMessage;
+            const rawFile = msgPayload.file;
+            const files: FileContent[] = !rawFile
+              ? []
+              : Array.isArray(rawFile)
+              ? (rawFile as FileContent[])
+              : [rawFile as FileContent];
+            return editThreadMessageWithFiles(
+              singleSuccsessMessageObject!.channelId,
+              singleSuccsessMessageObject!.messageId,
+              msgPayload.content,
+              (msgPayload.embeds ?? []) as Embed[],
+              files,
+            ).finally((): null => (singleSuccsessMessageObject = null));
+          }
+          return await bot.helpers
+            .editFollowupMessage(
+              singleSuccsessMessageObject!.token,
+              singleSuccsessMessageObject!.messageId,
+              Messages.createSuccessMessage({
+                runNumber: singleSuccsessMessageObject!.runNumber,
+                runTime: runTime,
+                totalSize: singleSuccsessMessageObject!.totalSize,
+                fileName: singleSuccsessMessageObject!.fileName,
+                link: singleSuccsessMessageObject!.link,
+                file: singleSuccsessMessageObject!.file,
+                spoiler: singleSuccsessMessageObject!.spoiler,
+              }),
+            )
+            .finally((): null => (singleSuccsessMessageObject = null));
+        },
       )
       .with(
         false,
@@ -112,38 +171,49 @@ const successMessage = {
     return Match(isEditOriginalMessage)
       .with(
         true,
-        async (): Promise<Message> =>
-          useThread
-            ? await bot.helpers
-                .editMessage(
-                  multiSuccsessMessageObject!.channelId,
-                  multiSuccsessMessageObject!.messageId,
-                  Messages.createSuccessMessage({
-                    runNumber: multiSuccsessMessageObject!.runNumber,
-                    runTime: runTime,
-                    totalSize: multiSuccsessMessageObject!.totalSize,
-                    fileNamesArray: multiSuccsessMessageObject!.fileNamesArray,
-                    link: multiSuccsessMessageObject!.link,
-                    filesArray: multiSuccsessMessageObject!.filesArray,
-                    spoiler: multiSuccsessMessageObject!.spoiler,
-                  }) as EditMessage,
-                )
-                .finally((): null => (multiSuccsessMessageObject = null))
-            : await bot.helpers
-                .editFollowupMessage(
-                  multiSuccsessMessageObject!.token,
-                  multiSuccsessMessageObject!.messageId,
-                  Messages.createSuccessMessage({
-                    runNumber: multiSuccsessMessageObject!.runNumber,
-                    runTime: runTime,
-                    totalSize: multiSuccsessMessageObject!.totalSize,
-                    fileNamesArray: multiSuccsessMessageObject!.fileNamesArray,
-                    link: multiSuccsessMessageObject!.link,
-                    filesArray: multiSuccsessMessageObject!.filesArray,
-                    spoiler: multiSuccsessMessageObject!.spoiler,
-                  }),
-                )
-                .finally((): null => (multiSuccsessMessageObject = null)),
+        async (): Promise<Message> => {
+          if (useThread) {
+            // Thread mode: use manual multipart PATCH to include `attachments`
+            // in payload_json (discordeno v18 omits this — see JSDoc above).
+            const msgPayload = Messages.createSuccessMessage({
+              runNumber: multiSuccsessMessageObject!.runNumber,
+              runTime: runTime,
+              totalSize: multiSuccsessMessageObject!.totalSize,
+              fileNamesArray: multiSuccsessMessageObject!.fileNamesArray,
+              link: multiSuccsessMessageObject!.link,
+              filesArray: multiSuccsessMessageObject!.filesArray,
+              spoiler: multiSuccsessMessageObject!.spoiler,
+            }) as CreateMessage;
+            const rawFile = msgPayload.file;
+            const files: FileContent[] = !rawFile
+              ? []
+              : Array.isArray(rawFile)
+              ? (rawFile as FileContent[])
+              : [rawFile as FileContent];
+            return editThreadMessageWithFiles(
+              multiSuccsessMessageObject!.channelId,
+              multiSuccsessMessageObject!.messageId,
+              msgPayload.content,
+              (msgPayload.embeds ?? []) as Embed[],
+              files,
+            ).finally((): null => (multiSuccsessMessageObject = null));
+          }
+          return await bot.helpers
+            .editFollowupMessage(
+              multiSuccsessMessageObject!.token,
+              multiSuccsessMessageObject!.messageId,
+              Messages.createSuccessMessage({
+                runNumber: multiSuccsessMessageObject!.runNumber,
+                runTime: runTime,
+                totalSize: multiSuccsessMessageObject!.totalSize,
+                fileNamesArray: multiSuccsessMessageObject!.fileNamesArray,
+                link: multiSuccsessMessageObject!.link,
+                filesArray: multiSuccsessMessageObject!.filesArray,
+                spoiler: multiSuccsessMessageObject!.spoiler,
+              }),
+            )
+            .finally((): null => (multiSuccsessMessageObject = null));
+        },
       )
       .with(
         false,

--- a/tests/router/functions/callbackSuccessFunctions.test.ts
+++ b/tests/router/functions/callbackSuccessFunctions.test.ts
@@ -92,10 +92,15 @@ Deno.test("callbackSuccessFunctions — handleSingleSuccess", async (t) => {
     },
   );
 
-  // ── Case 2: threadDl (useThread=true) → editMessage ──
+  // ── Case 2: threadDl (useThread=true) → bot.rest.runMethod (not editMessage) ──
   await t.step(
-    "threadDl + no shardIndex → editMessage called, returns 204",
+    "threadDl + no shardIndex → bot.rest.runMethod called (not editMessage), returns 204",
     async () => {
+      const runMethod = stub(
+        bot.rest,
+        "runMethod",
+        () => Promise.resolve({}),
+      );
       const editMsg = stub(
         bot.helpers,
         "editMessage",
@@ -112,9 +117,11 @@ Deno.test("callbackSuccessFunctions — handleSingleSuccess", async (t) => {
           body: makeBody("threaddl") as never,
         });
         assertEquals(res.status, 204);
-        assertSpyCalls(editMsg, 1);
+        assertSpyCalls(runMethod, 1);
+        assertSpyCalls(editMsg, 0);
         assertSpyCalls(editFollowup, 0);
       } finally {
+        runMethod.restore();
         editMsg.restore();
         editFollowup.restore();
       }
@@ -123,16 +130,26 @@ Deno.test("callbackSuccessFunctions — handleSingleSuccess", async (t) => {
 
   // ── Case 3: threadDl + shardIndex → runNumber is "#N-XX" in embed ──
   await t.step(
-    "threadDl + shardIndex=02 → editMessage called with runNumber '1-02' in embed",
+    "threadDl + shardIndex=02 → runMethod called with runNumber '1-02' in embed",
     async () => {
-      let capturedPayload: unknown;
+      let capturedBody: unknown;
+      const runMethod = stub(
+        bot.rest,
+        "runMethod",
+        (
+          _rest: unknown,
+          _method: unknown,
+          _route: unknown,
+          body: unknown,
+        ) => {
+          capturedBody = body;
+          return Promise.resolve({});
+        },
+      );
       const editMsg = stub(
         bot.helpers,
         "editMessage",
-        (_ch, _msg, payload) => {
-          capturedPayload = payload;
-          return Promise.resolve(fakeMsg);
-        },
+        () => Promise.resolve(fakeMsg),
       );
       const editFollowup = stub(
         bot.helpers,
@@ -145,14 +162,16 @@ Deno.test("callbackSuccessFunctions — handleSingleSuccess", async (t) => {
           body: makeBody("threaddl", { shardIndex: "02" }) as never,
         });
         assertEquals(res.status, 204);
-        assertSpyCalls(editMsg, 1);
-        // The RUN_NUMBER embed field should contain "1-02"
+        assertSpyCalls(runMethod, 1);
+        assertSpyCalls(editMsg, 0);
+        // The RUN_NUMBER embed field should contain "1-02" (Discord wire format)
         const embed = (
-          capturedPayload as { embeds?: { fields?: { value: string }[] }[] }
+          capturedBody as { embeds?: { fields?: { value: string }[] }[] }
         )?.embeds?.[0];
         const runField = embed?.fields?.find((f) => f.value.includes("1-02"));
         assertEquals(runField !== undefined, true);
       } finally {
+        runMethod.restore();
         editMsg.restore();
         editFollowup.restore();
       }
@@ -223,18 +242,28 @@ Deno.test("callbackSuccessFunctions — handleSingleSuccess", async (t) => {
     }
   });
 
-  // ── Case 6: threadDlSpoiler + shardIndex → editMessage (spoiler+thread) ──
+  // ── Case 6: threadDlSpoiler + shardIndex → runMethod (spoiler+thread) ──
   await t.step(
-    "threadDlSpoiler + shardIndex=03 → editMessage called with '1-03' in embed",
+    "threadDlSpoiler + shardIndex=03 → runMethod called with '1-03' in embed",
     async () => {
-      let capturedPayload: unknown;
+      let capturedBody: unknown;
+      const runMethod = stub(
+        bot.rest,
+        "runMethod",
+        (
+          _rest: unknown,
+          _method: unknown,
+          _route: unknown,
+          body: unknown,
+        ) => {
+          capturedBody = body;
+          return Promise.resolve({});
+        },
+      );
       const editMsg = stub(
         bot.helpers,
         "editMessage",
-        (_ch, _msg, payload) => {
-          capturedPayload = payload;
-          return Promise.resolve(fakeMsg);
-        },
+        () => Promise.resolve(fakeMsg),
       );
       const editFollowup = stub(
         bot.helpers,
@@ -248,13 +277,15 @@ Deno.test("callbackSuccessFunctions — handleSingleSuccess", async (t) => {
             body: makeBody("threaddl-spoiler", { shardIndex: "03" }) as never,
           });
         assertEquals(res.status, 204);
-        assertSpyCalls(editMsg, 1);
+        assertSpyCalls(runMethod, 1);
+        assertSpyCalls(editMsg, 0);
         const embed = (
-          capturedPayload as { embeds?: { fields?: { value: string }[] }[] }
+          capturedBody as { embeds?: { fields?: { value: string }[] }[] }
         )?.embeds?.[0];
         const runField = embed?.fields?.find((f) => f.value.includes("1-03"));
         assertEquals(runField !== undefined, true);
       } finally {
+        runMethod.restore();
         editMsg.restore();
         editFollowup.restore();
       }
@@ -292,18 +323,28 @@ Deno.test("callbackSuccessFunctions — handleMultiSuccess", async (t) => {
     },
   );
 
-  // ── Case 8: threadDl multi + shardIndex → editMessage with "#N-XX" ──
+  // ── Case 8: threadDl multi + shardIndex → runMethod with "#N-XX" ──
   await t.step(
-    "threadDl.multi + shardIndex=01 → editMessage called with '1-01' in embed",
+    "threadDl.multi + shardIndex=01 → runMethod called with '1-01' in embed",
     async () => {
-      let capturedPayload: unknown;
+      let capturedBody: unknown;
+      const runMethod = stub(
+        bot.rest,
+        "runMethod",
+        (
+          _rest: unknown,
+          _method: unknown,
+          _route: unknown,
+          body: unknown,
+        ) => {
+          capturedBody = body;
+          return Promise.resolve({});
+        },
+      );
       const editMsg = stub(
         bot.helpers,
         "editMessage",
-        (_ch, _msg, payload) => {
-          capturedPayload = payload;
-          return Promise.resolve(fakeMsg);
-        },
+        () => Promise.resolve(fakeMsg),
       );
       const editFollowup = stub(
         bot.helpers,
@@ -316,13 +357,15 @@ Deno.test("callbackSuccessFunctions — handleMultiSuccess", async (t) => {
           body: makeMultiBody("threaddl", { shardIndex: "01" }) as never,
         });
         assertEquals(res.status, 204);
-        assertSpyCalls(editMsg, 1);
+        assertSpyCalls(runMethod, 1);
+        assertSpyCalls(editMsg, 0);
         const embed = (
-          capturedPayload as { embeds?: { fields?: { value: string }[] }[] }
+          capturedBody as { embeds?: { fields?: { value: string }[] }[] }
         )?.embeds?.[0];
         const runField = embed?.fields?.find((f) => f.value.includes("1-01"));
         assertEquals(runField !== undefined, true);
       } finally {
+        runMethod.restore();
         editMsg.restore();
         editFollowup.restore();
       }

--- a/tests/router/messages/successMessage.test.ts
+++ b/tests/router/messages/successMessage.test.ts
@@ -60,10 +60,15 @@ const makeMultiObj = (
 // ---------------------------------------------------------------------------
 
 Deno.test("successMessage.singleFile", async (t) => {
-  // ── Case 1: useThread=true → editMessage (short-circuits all other gates) ──
+  // ── Case 1: useThread=true → bot.rest.runMethod (not editMessage) ──
   await t.step(
-    "useThread=true → calls editMessage regardless of runtime/oversize",
+    "useThread=true → calls bot.rest.runMethod regardless of runtime/oversize",
     async () => {
+      const runMethod = stub(
+        bot.rest,
+        "runMethod",
+        () => Promise.resolve({}),
+      );
       const editMsg = stub(
         bot.helpers,
         "editMessage",
@@ -83,10 +88,58 @@ Deno.test("successMessage.singleFile", async (t) => {
         await successMessage.singleFile(
           makeSingleObj(true, "true", String(Date.now() - (LIMIT + 60_000))),
         );
-        assertSpyCalls(editMsg, 1);
+        assertSpyCalls(runMethod, 1);
+        assertSpyCalls(editMsg, 0);
         assertSpyCalls(editFollowup, 0);
         assertSpyCalls(sendMsg, 0);
       } finally {
+        runMethod.restore();
+        editMsg.restore();
+        editFollowup.restore();
+        sendMsg.restore();
+      }
+    },
+  );
+
+  // ── Case 1b: useThread=true → payload_json contains attachments ──
+  await t.step(
+    "useThread=true → runMethod body includes attachments: [{id:0, filename}]",
+    async () => {
+      let capturedBody: unknown;
+      const runMethod = stub(
+        bot.rest,
+        "runMethod",
+        (_rest: unknown, _method: unknown, _route: unknown, body: unknown) => {
+          capturedBody = body;
+          return Promise.resolve({});
+        },
+      );
+      const editMsg = stub(
+        bot.helpers,
+        "editMessage",
+        () => Promise.resolve(fakeMsg),
+      );
+      const editFollowup = stub(
+        bot.helpers,
+        "editFollowupMessage",
+        () => Promise.resolve(fakeMsg),
+      );
+      const sendMsg = stub(
+        bot.helpers,
+        "sendMessage",
+        () => Promise.resolve(fakeMsg),
+      );
+      try {
+        await successMessage.singleFile(makeSingleObj(true, "false"));
+        assertSpyCalls(runMethod, 1);
+        const body = capturedBody as {
+          attachments?: { id: number; filename: string }[];
+        };
+        assertEquals(Array.isArray(body.attachments), true);
+        assertEquals(body.attachments?.[0]?.id, 0);
+        assertEquals(body.attachments?.[0]?.filename, "video.mp4");
+      } finally {
+        runMethod.restore();
         editMsg.restore();
         editFollowup.restore();
         sendMsg.restore();
@@ -201,10 +254,15 @@ Deno.test("successMessage.singleFile", async (t) => {
 // ---------------------------------------------------------------------------
 
 Deno.test("successMessage.multiFiles", async (t) => {
-  // ── Case 5: useThread=true → editMessage ──
+  // ── Case 5: useThread=true → bot.rest.runMethod (not editMessage) ──
   await t.step(
-    "useThread=true → calls editMessage regardless of runtime/oversize",
+    "useThread=true → calls bot.rest.runMethod regardless of runtime/oversize",
     async () => {
+      const runMethod = stub(
+        bot.rest,
+        "runMethod",
+        () => Promise.resolve({}),
+      );
       const editMsg = stub(
         bot.helpers,
         "editMessage",
@@ -224,10 +282,59 @@ Deno.test("successMessage.multiFiles", async (t) => {
         await successMessage.multiFiles(
           makeMultiObj(true, "true", String(Date.now() - (LIMIT + 60_000))),
         );
-        assertSpyCalls(editMsg, 1);
+        assertSpyCalls(runMethod, 1);
+        assertSpyCalls(editMsg, 0);
         assertSpyCalls(editFollowup, 0);
         assertSpyCalls(sendMsg, 0);
       } finally {
+        runMethod.restore();
+        editMsg.restore();
+        editFollowup.restore();
+        sendMsg.restore();
+      }
+    },
+  );
+
+  // ── Case 5b: useThread=true, multi-file → attachments has 2 entries ──
+  await t.step(
+    "useThread=true, multi-file → attachments: [{id:0},{id:1}] with correct filenames",
+    async () => {
+      let capturedBody: unknown;
+      const runMethod = stub(
+        bot.rest,
+        "runMethod",
+        (_rest: unknown, _method: unknown, _route: unknown, body: unknown) => {
+          capturedBody = body;
+          return Promise.resolve({});
+        },
+      );
+      const editMsg = stub(
+        bot.helpers,
+        "editMessage",
+        () => Promise.resolve(fakeMsg),
+      );
+      const editFollowup = stub(
+        bot.helpers,
+        "editFollowupMessage",
+        () => Promise.resolve(fakeMsg),
+      );
+      const sendMsg = stub(
+        bot.helpers,
+        "sendMessage",
+        () => Promise.resolve(fakeMsg),
+      );
+      try {
+        await successMessage.multiFiles(makeMultiObj(true, "false"));
+        assertSpyCalls(runMethod, 1);
+        const body = capturedBody as {
+          attachments?: { id: number; filename: string }[];
+        };
+        assertEquals(Array.isArray(body.attachments), true);
+        assertEquals(body.attachments?.length, 2);
+        assertEquals(body.attachments?.[0], { id: 0, filename: "clip1.mp4" });
+        assertEquals(body.attachments?.[1], { id: 1, filename: "clip2.mp4" });
+      } finally {
+        runMethod.restore();
         editMsg.restore();
         editFollowup.restore();
         sendMsg.restore();
@@ -301,10 +408,15 @@ Deno.test("successMessage.multiFiles", async (t) => {
     },
   );
 
-  // ── Case 8: useThread=true, runTime > LIMIT, oversize=true → editMessage ──
+  // ── Case 8: useThread=true, runTime > LIMIT, oversize=true → runMethod ──
   await t.step(
-    "useThread=true, runTime > 15 min, oversize=true → editMessage (useThread wins all)",
+    "useThread=true, runTime > 15 min, oversize=true → bot.rest.runMethod (useThread wins all)",
     async () => {
+      const runMethod = stub(
+        bot.rest,
+        "runMethod",
+        () => Promise.resolve({}),
+      );
       const editMsg = stub(
         bot.helpers,
         "editMessage",
@@ -324,10 +436,12 @@ Deno.test("successMessage.multiFiles", async (t) => {
         await successMessage.multiFiles(
           makeMultiObj(true, "true", String(Date.now() - (LIMIT + 60_000))),
         );
-        assertSpyCalls(editMsg, 1);
+        assertSpyCalls(runMethod, 1);
+        assertSpyCalls(editMsg, 0);
         assertSpyCalls(editFollowup, 0);
         assertSpyCalls(sendMsg, 0);
       } finally {
+        runMethod.restore();
         editMsg.restore();
         editFollowup.restore();
         sendMsg.restore();


### PR DESCRIPTION
## 問題

thread mode の success callback で **embed は更新されるがファイルが添付されない**現象が発生していた。

### 根本原因

discordeno v18 の `editMessage` が内部で multipart PATCH を構築する際、`createRequestBody.ts` が:

```js
form.append("payload_json", JSON.stringify({ ...body, file: undefined }));
```

...と body を展開するが **`attachments` 配列を含めない**。

Discord の PATCH `/channels/{id}/messages/{id}` API（2022 年仕様更新）では新規ファイルを添付するために `payload_json.attachments` に zero-based index 参照が必要:

```json
{ "attachments": [{"id": 0, "filename": "video.mp4"}], "embeds": [...] }
```

これがないと Discord はファイルデータを受信しても **無音でドロップ**する。非 thread mode は `sendMessage`（POST）を使用するため影響なし。

## 修正

`successMessage.ts` に `editThreadMessageWithFiles()` ヘルパーを追加し、`bot.helpers.editMessage` の代わりに `bot.rest.runMethod` を直接呼び出す:

```ts
await bot.rest.runMethod(bot.rest, "PATCH", route, {
  embeds: embeds.map(e => bot.transformers.reverse.embed(bot, e)),
  file: files.length === 1 ? files[0] : files,
  // Discord API 要件: payload_json に attachments 参照を含める
  attachments: files.map((f, i) => ({ id: i, filename: f.name })),
});
```

discordeno の `createRequestBody` が body を `payload_json` に展開するため、`attachments` は自動的に含まれる。将来 discordeno がこのバグを修正した場合は `bot.helpers.editMessage` に戻すこと（コメント付き）。

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `src/router/messages/successMessage.ts` | `editThreadMessageWithFiles` ヘルパー追加、thread mode を `bot.rest.runMethod` 直接呼び出しに変更 |
| `tests/router/messages/successMessage.test.ts` | thread mode を `bot.rest.runMethod` stub に切り替え、`attachments` 検証追加 |
| `tests/router/functions/callbackSuccessFunctions.test.ts` | thread mode を `bot.rest.runMethod` stub に切り替え、embed フィールド検証は Discord wire format 対応済み |

## テスト

- `ok | 22 passed (112 steps) | 0 failed`（bot/ + libs/ + router/ サブセット）
- successMessage thread 新規ケース: `attachments[0].id === 0`, `filename === "video.mp4"`
- successMessage multiFiles 新規ケース: `attachments[0] === {id:0, filename:"clip1.mp4"}`, `attachments[1] === {id:1, filename:"clip2.mp4"}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)