### PR TITLE
refactor(b1): fix naming typos (badRequst, Succsess, catch-paren)

### DIFF
--- a/src/libs/contents/singleFileContent.ts
+++ b/src/libs/contents/singleFileContent.ts
@@ -24,7 +24,7 @@ const singleFileContent = (
       fileName: body!.name1,
       blobData: body!.file1 as unknown as Blob,
     });
-  } catch(e: unknown) {
+  } catch (e: unknown) {
     return Promise.reject(e as Error);
   } finally {
     body = null;

--- a/src/router/callback.ts
+++ b/src/router/callback.ts
@@ -13,7 +13,7 @@ type CallbackPath = typeof Constants.CALLBACK_PATH;
 type HonoType<T extends string> = CallbackTypes.honoType<T>;
 type ContentType<T extends string> = CallbackTypes.contextType<T>;
 
-const badRequst = Constants.HttpStatus.BAD_REQUEST;
+const badRequest = Constants.HttpStatus.BAD_REQUEST;
 const serverError = Constants.HttpStatus.INTERNAL_SERVER_ERROR;
 
 const callbackPath = Constants.CALLBACK_PATH;
@@ -149,7 +149,7 @@ callback.post(
       )
       .with(
         callbackPattern.InvalidPost,
-        (): Promise<Response> => Promise.resolve(c.body(null, badRequst)),
+        (): Promise<Response> => Promise.resolve(c.body(null, badRequest)),
       )
       .otherwise(
         (): Promise<Response> => Promise.resolve(c.body(null, serverError)),

--- a/src/router/messages/successMessage.ts
+++ b/src/router/messages/successMessage.ts
@@ -5,9 +5,9 @@ import type { FileContent, CreateMessage } from "discordeno";
 import { Messages, Constants } from "@libs";
 import { CreateMessageTypes } from "@router/types/createMessageTypes.ts";
 
-type SingleSuccsessMessageObject =
+type SingleSuccessMessageObject =
   CreateMessageTypes.SendSuccessMessage.singleFileObject | null;
-type MultiSuccsessMessageObject =
+type MultiSuccessMessageObject =
   CreateMessageTypes.SendSuccessMessage.multiFilesObject | null;
 
 const trueOversize = Constants.CallbackObject.Oversize.TRUE;
@@ -82,22 +82,22 @@ const successMessage = {
   /**
    * Asynchronously handles a single success message and sends it based on conditions.
    *
-   * @param {SingleSuccsessMessageObject} singleSuccsessMessageObject - The object containing the single success message details.
+   * @param {SingleSuccessMessageObject} singleSuccessMessageObject - The object containing the single success message details.
    * @return {Promise<Message>} A promise that resolves to a message response.
    */
   singleFile: (
-    singleSuccsessMessageObject: SingleSuccsessMessageObject,
+    singleSuccessMessageObject: SingleSuccessMessageObject,
   ): Promise<Message> => {
     const runTime: number =
-      new Date().getTime() - Number(singleSuccsessMessageObject!.startTime);
-    const useThread: boolean = !!singleSuccsessMessageObject!.useThread;
+      new Date().getTime() - Number(singleSuccessMessageObject!.startTime);
+    const useThread: boolean = !!singleSuccessMessageObject!.useThread;
     // editMessage (thread mode) is not bound by the 15-min interaction-token
     // window or the followup oversize fallback, so always edit the
     // placeholder when running in a thread.
     const isEditOriginalMessage: boolean =
       useThread ||
       runTime <= editFollowupMessageTimeLimit ||
-      singleSuccsessMessageObject!.oversize !== trueOversize;
+      singleSuccessMessageObject!.oversize !== trueOversize;
     return Match(isEditOriginalMessage)
       .with(
         true,
@@ -106,13 +106,13 @@ const successMessage = {
             // Thread mode: use manual multipart PATCH to include `attachments`
             // in payload_json (discordeno v18 omits this — see JSDoc above).
             const msgPayload = Messages.createSuccessMessage({
-              runNumber: singleSuccsessMessageObject!.runNumber,
+              runNumber: singleSuccessMessageObject!.runNumber,
               runTime: runTime,
-              totalSize: singleSuccsessMessageObject!.totalSize,
-              fileName: singleSuccsessMessageObject!.fileName,
-              link: singleSuccsessMessageObject!.link,
-              file: singleSuccsessMessageObject!.file,
-              spoiler: singleSuccsessMessageObject!.spoiler,
+              totalSize: singleSuccessMessageObject!.totalSize,
+              fileName: singleSuccessMessageObject!.fileName,
+              link: singleSuccessMessageObject!.link,
+              file: singleSuccessMessageObject!.file,
+              spoiler: singleSuccessMessageObject!.spoiler,
             }) as CreateMessage;
             const rawFile = msgPayload.file;
             const files: FileContent[] = !rawFile
@@ -121,28 +121,28 @@ const successMessage = {
               ? (rawFile as FileContent[])
               : [rawFile as FileContent];
             return editThreadMessageWithFiles(
-              singleSuccsessMessageObject!.channelId,
-              singleSuccsessMessageObject!.messageId,
+              singleSuccessMessageObject!.channelId,
+              singleSuccessMessageObject!.messageId,
               msgPayload.content,
               (msgPayload.embeds ?? []) as Embed[],
               files,
-            ).finally((): null => (singleSuccsessMessageObject = null));
+            ).finally((): null => (singleSuccessMessageObject = null));
           }
           return await bot.helpers
             .editFollowupMessage(
-              singleSuccsessMessageObject!.token,
-              singleSuccsessMessageObject!.messageId,
+              singleSuccessMessageObject!.token,
+              singleSuccessMessageObject!.messageId,
               Messages.createSuccessMessage({
-                runNumber: singleSuccsessMessageObject!.runNumber,
+                runNumber: singleSuccessMessageObject!.runNumber,
                 runTime: runTime,
-                totalSize: singleSuccsessMessageObject!.totalSize,
-                fileName: singleSuccsessMessageObject!.fileName,
-                link: singleSuccsessMessageObject!.link,
-                file: singleSuccsessMessageObject!.file,
-                spoiler: singleSuccsessMessageObject!.spoiler,
+                totalSize: singleSuccessMessageObject!.totalSize,
+                fileName: singleSuccessMessageObject!.fileName,
+                link: singleSuccessMessageObject!.link,
+                file: singleSuccessMessageObject!.file,
+                spoiler: singleSuccessMessageObject!.spoiler,
               }),
             )
-            .finally((): null => (singleSuccsessMessageObject = null));
+            .finally((): null => (singleSuccessMessageObject = null));
         },
       )
       .with(
@@ -150,42 +150,42 @@ const successMessage = {
         async (): Promise<Message> =>
           await bot.helpers
             .sendMessage(
-              singleSuccsessMessageObject!.channelId,
+              singleSuccessMessageObject!.channelId,
               Messages.createSuccessMessage({
-                messageId: singleSuccsessMessageObject!.messageId,
-                channelId: singleSuccsessMessageObject!.channelId,
-                runNumber: singleSuccsessMessageObject!.runNumber,
+                messageId: singleSuccessMessageObject!.messageId,
+                channelId: singleSuccessMessageObject!.channelId,
+                runNumber: singleSuccessMessageObject!.runNumber,
                 runTime: runTime,
-                totalSize: singleSuccsessMessageObject!.totalSize,
-                fileName: singleSuccsessMessageObject!.fileName,
-                link: singleSuccsessMessageObject!.link,
-                file: singleSuccsessMessageObject!.file,
-                spoiler: singleSuccsessMessageObject!.spoiler,
+                totalSize: singleSuccessMessageObject!.totalSize,
+                fileName: singleSuccessMessageObject!.fileName,
+                link: singleSuccessMessageObject!.link,
+                file: singleSuccessMessageObject!.file,
+                spoiler: singleSuccessMessageObject!.spoiler,
               }),
             )
-            .finally((): null => (singleSuccsessMessageObject = null)),
+            .finally((): null => (singleSuccessMessageObject = null)),
       )
       .exhaustive();
   },
   /**
    * Asynchronously handles multiple success messages and sends them based on conditions.
    *
-   * @param {MultiSuccsessMessageObject} multiSuccsessMessageObject - The object containing the multiple success message details.
+   * @param {MultiSuccessMessageObject} multiSuccessMessageObject - The object containing the multiple success message details.
    * @return {Promise<Message>} A promise that resolves to a message response.
    */
   multiFiles: (
-    multiSuccsessMessageObject: MultiSuccsessMessageObject,
+    multiSuccessMessageObject: MultiSuccessMessageObject,
   ): Promise<Message> => {
     const runTime: number =
-      new Date().getTime() - Number(multiSuccsessMessageObject!.startTime);
-    const useThread: boolean = !!multiSuccsessMessageObject!.useThread;
+      new Date().getTime() - Number(multiSuccessMessageObject!.startTime);
+    const useThread: boolean = !!multiSuccessMessageObject!.useThread;
     // editMessage (thread mode) is not bound by the 15-min interaction-token
     // window or the followup oversize fallback, so always edit the
     // placeholder when running in a thread.
     const isEditOriginalMessage: boolean =
       useThread ||
       runTime <= editFollowupMessageTimeLimit ||
-      multiSuccsessMessageObject!.oversize !== trueOversize;
+      multiSuccessMessageObject!.oversize !== trueOversize;
     return Match(isEditOriginalMessage)
       .with(
         true,
@@ -194,13 +194,13 @@ const successMessage = {
             // Thread mode: use manual multipart PATCH to include `attachments`
             // in payload_json (discordeno v18 omits this — see JSDoc above).
             const msgPayload = Messages.createSuccessMessage({
-              runNumber: multiSuccsessMessageObject!.runNumber,
+              runNumber: multiSuccessMessageObject!.runNumber,
               runTime: runTime,
-              totalSize: multiSuccsessMessageObject!.totalSize,
-              fileNamesArray: multiSuccsessMessageObject!.fileNamesArray,
-              link: multiSuccsessMessageObject!.link,
-              filesArray: multiSuccsessMessageObject!.filesArray,
-              spoiler: multiSuccsessMessageObject!.spoiler,
+              totalSize: multiSuccessMessageObject!.totalSize,
+              fileNamesArray: multiSuccessMessageObject!.fileNamesArray,
+              link: multiSuccessMessageObject!.link,
+              filesArray: multiSuccessMessageObject!.filesArray,
+              spoiler: multiSuccessMessageObject!.spoiler,
             }) as CreateMessage;
             const rawFile = msgPayload.file;
             const files: FileContent[] = !rawFile
@@ -209,28 +209,28 @@ const successMessage = {
               ? (rawFile as FileContent[])
               : [rawFile as FileContent];
             return editThreadMessageWithFiles(
-              multiSuccsessMessageObject!.channelId,
-              multiSuccsessMessageObject!.messageId,
+              multiSuccessMessageObject!.channelId,
+              multiSuccessMessageObject!.messageId,
               msgPayload.content,
               (msgPayload.embeds ?? []) as Embed[],
               files,
-            ).finally((): null => (multiSuccsessMessageObject = null));
+            ).finally((): null => (multiSuccessMessageObject = null));
           }
           return await bot.helpers
             .editFollowupMessage(
-              multiSuccsessMessageObject!.token,
-              multiSuccsessMessageObject!.messageId,
+              multiSuccessMessageObject!.token,
+              multiSuccessMessageObject!.messageId,
               Messages.createSuccessMessage({
-                runNumber: multiSuccsessMessageObject!.runNumber,
+                runNumber: multiSuccessMessageObject!.runNumber,
                 runTime: runTime,
-                totalSize: multiSuccsessMessageObject!.totalSize,
-                fileNamesArray: multiSuccsessMessageObject!.fileNamesArray,
-                link: multiSuccsessMessageObject!.link,
-                filesArray: multiSuccsessMessageObject!.filesArray,
-                spoiler: multiSuccsessMessageObject!.spoiler,
+                totalSize: multiSuccessMessageObject!.totalSize,
+                fileNamesArray: multiSuccessMessageObject!.fileNamesArray,
+                link: multiSuccessMessageObject!.link,
+                filesArray: multiSuccessMessageObject!.filesArray,
+                spoiler: multiSuccessMessageObject!.spoiler,
               }),
             )
-            .finally((): null => (multiSuccsessMessageObject = null));
+            .finally((): null => (multiSuccessMessageObject = null));
         },
       )
       .with(
@@ -238,20 +238,20 @@ const successMessage = {
         async (): Promise<Message> =>
           await bot.helpers
             .sendMessage(
-              multiSuccsessMessageObject!.channelId,
+              multiSuccessMessageObject!.channelId,
               Messages.createSuccessMessage({
-                messageId: multiSuccsessMessageObject!.messageId,
-                channelId: multiSuccsessMessageObject!.channelId,
-                runNumber: multiSuccsessMessageObject!.runNumber,
+                messageId: multiSuccessMessageObject!.messageId,
+                channelId: multiSuccessMessageObject!.channelId,
+                runNumber: multiSuccessMessageObject!.runNumber,
                 runTime: runTime,
-                totalSize: multiSuccsessMessageObject!.totalSize,
-                fileNamesArray: multiSuccsessMessageObject!.fileNamesArray,
-                link: multiSuccsessMessageObject!.link,
-                filesArray: multiSuccsessMessageObject!.filesArray,
-                spoiler: multiSuccsessMessageObject!.spoiler,
+                totalSize: multiSuccessMessageObject!.totalSize,
+                fileNamesArray: multiSuccessMessageObject!.fileNamesArray,
+                link: multiSuccessMessageObject!.link,
+                filesArray: multiSuccessMessageObject!.filesArray,
+                spoiler: multiSuccessMessageObject!.spoiler,
               }),
             )
-            .finally((): null => (multiSuccsessMessageObject = null)),
+            .finally((): null => (multiSuccessMessageObject = null)),
       )
       .exhaustive();
   },


### PR DESCRIPTION
## Summary

Coding-guidelines Rule 7 (Naming Conventions) compliance — typo-only fixes, zero behavior change.

| File | Before | After | Rule |
|------|--------|-------|------|
| `src/router/callback.ts` L16, L152 | `badRequst` | `badRequest` | Rule 7: camelCase, correct spelling |
| `src/router/messages/successMessage.ts` L8, L10 | `SingleSuccsessMessageObject` / `MultiSuccsessMessageObject` | `Single/MultiSuccessMessageObject` | Rule 7: correct spelling |
| `src/router/messages/successMessage.ts` (all usages) | `singleSuccsessMessageObject` / `multiSuccsessMessageObject` | `single/multiSuccessMessageObject` | Rule 7: correct spelling |
| `src/libs/contents/singleFileContent.ts` L27 | `catch(e:` | `catch (e:` | Style: space before `(` |

## Before / After

### `src/router/callback.ts`
```typescript
// Before
const badRequst = Constants.HttpStatus.BAD_REQUEST;
// ...
(): Promise<Response> => Promise.resolve(c.body(null, badRequst)),

// After
const badRequest = Constants.HttpStatus.BAD_REQUEST;
// ...
(): Promise<Response> => Promise.resolve(c.body(null, badRequest)),
```

### `src/router/messages/successMessage.ts`
```typescript
// Before
type SingleSuccsessMessageObject = ...
type MultiSuccsessMessageObject = ...
singleFile: (singleSuccsessMessageObject: SingleSuccsessMessageObject) => { ... }
multiFiles: (multiSuccsessMessageObject: MultiSuccsessMessageObject) => { ... }

// After
type SingleSuccessMessageObject = ...
type MultiSuccessMessageObject = ...
singleFile: (singleSuccessMessageObject: SingleSuccessMessageObject) => { ... }
multiFiles: (multiSuccessMessageObject: MultiSuccessMessageObject) => { ... }
```

### `src/libs/contents/singleFileContent.ts`
```typescript
// Before
  } catch(e: unknown) {
// After
  } catch (e: unknown) {
```

## Coding-guidelines compliance

- **Rule 7 — Naming Conventions**: All identifiers now correctly spelled; no SCREAMING_SNAKE_CASE outside `Constants`
- No other rules affected (type aliases are compile-time only, erased at runtime)

## Test plan

- [x] `deno lint` — passes on changed files
- [x] `deno task test` — 28 passed, 0 failed (all 144 steps)
- [x] No test file changes required (type aliases are runtime-erased; `badRequest` is file-local)

🤖 Generated with [Claude Code](https://claude.com/claude-code)