### PR TITLE
refactor(b2): convert function declaration to const arrow (Rule 2)

### DIFF
--- a/src/router/messages/successMessage.ts
+++ b/src/router/messages/successMessage.ts
@@ -30,13 +30,13 @@ const editFollowupMessageTimeLimit = Constants.EDIT_FOLLOWUP_MESSAGE_TIME_LIMIT;
  * names.  If a future discordeno release fixes the naming, revert to
  * `bot.helpers.editMessage`.
  */
-async function editThreadMessageWithFiles(
+const editThreadMessageWithFiles = async (
   channelId: bigint | string,
   messageId: bigint | string,
   content: string | null | undefined,
   embeds: Embed[],
   files: FileContent[],
-): Promise<Message> {
+): Promise<Message> => {
   const form = new FormData();
   // Use `files[N]` bracket notation — required by Discord's PATCH attachment API.
   files.forEach((f, i) => form.append(`files[${i}]`, f.blob, f.name));
@@ -76,7 +76,7 @@ async function editThreadMessageWithFiles(
   // Callers chain .then()/.catch() on the returned Promise but never use the
   // Message value directly, so an empty cast is safe here.
   return {} as unknown as Message;
-}
+};
 
 const successMessage = {
   /**


### PR DESCRIPTION
## Summary

Coding-guidelines Rule 2 (Function Definitions) compliance — the only remaining `function` declaration converted to `const` arrow. Zero behavior change.

## Before / After

**`src/router/messages/successMessage.ts` (lines 33–79)**

```typescript
// Before — `function` declaration (prohibited by Rule 2)
async function editThreadMessageWithFiles(
  channelId: bigint | string,
  messageId: bigint | string,
  content: string | null | undefined,
  embeds: Embed[],
  files: FileContent[],
): Promise<Message> {
  // ...
}

// After — const arrow (Rule 2 compliant)
const editThreadMessageWithFiles = async (
  channelId: bigint | string,
  messageId: bigint | string,
  content: string | null | undefined,
  embeds: Embed[],
  files: FileContent[],
): Promise<Message> => {
  // ...
};
```

## Coding-guidelines compliance

- **Rule 2 — Function Definitions**: `function` declarations are now completely absent from `src/`. All functions use `const fn = (...): T => { ... }`.
- Rationale: prevents accidental rebinding; return type visible at definition site; avoids hoisting that could obscure order-dependent logic.

## Why no behavior change

`function` hoisting is irrelevant here: `editThreadMessageWithFiles` is a file-private helper defined at module level and called only at lines 123 and 211 — both after the definition. Callers continue to work identically.

## Test plan

- [x] `deno lint` — passes
- [x] `deno task test` — 28 passed, 0 failed (144 steps); thread-mode cases in `tests/router/messages/successMessage.test.ts` exercise `editThreadMessageWithFiles` directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)