### PR TITLE
refactor(b3): fix import order — local aliases before external libs (Rule 1)

### DIFF
--- a/src/bot/runThreadFlow.ts
+++ b/src/bot/runThreadFlow.ts
@@ -1,3 +1,4 @@
+import { Messages, Constants, isUrl, webhookThread } from "@libs";
 import { If } from "functional";
 import { KyResponse } from "ky";
 import {
@@ -8,7 +9,6 @@ import {
   InteractionResponseTypes,
   Message,
 } from "discordeno";
-import { Messages, Constants, isUrl, webhookThread } from "@libs";
 
 /**
  * Pure "do the thread thing" flow shared by:

--- a/src/bot/threadModalSubmit.ts
+++ b/src/bot/threadModalSubmit.ts
@@ -1,6 +1,6 @@
-import { Constants } from "@libs";
 import { runThreadFlow } from "@bot/runThreadFlow.ts";
 import { URLS_INPUT_CUSTOM_ID } from "@bot/threadInteractionCreate.ts";
+import { Constants } from "@libs";
 import { Bot, Interaction } from "discordeno";
 
 type InteractionData = Exclude<Pick<Interaction, "data">["data"], undefined>;

--- a/src/bot/threadModalSubmit.ts
+++ b/src/bot/threadModalSubmit.ts
@@ -1,7 +1,7 @@
-import { Bot, Interaction } from "discordeno";
 import { Constants } from "@libs";
 import { runThreadFlow } from "@bot/runThreadFlow.ts";
 import { URLS_INPUT_CUSTOM_ID } from "@bot/threadInteractionCreate.ts";
+import { Bot, Interaction } from "discordeno";
 
 type InteractionData = Exclude<Pick<Interaction, "data">["data"], undefined>;
 type InteractionDataComponents = Exclude<

--- a/src/libs/contents/multiFilesContent.ts
+++ b/src/libs/contents/multiFilesContent.ts
@@ -1,6 +1,6 @@
-import { FileContent } from "discordeno";
 import { ContentsTypes } from "@libs/types/contentsTypes.ts";
 import { CallbackTypes } from "@router/types/callbackTypes.ts";
+import { FileContent } from "discordeno";
 
 /**
  * Retrieves the content of multiple files from the given body data object.

--- a/src/libs/messages/createErrorMessage.ts
+++ b/src/libs/messages/createErrorMessage.ts
@@ -1,6 +1,6 @@
 import { Constants } from "@libs";
-import { CreateMessage, InteractionCallbackData } from "discordeno";
 import { CreateMessageTypes } from "@router/types/createMessageTypes.ts";
+import { CreateMessage, InteractionCallbackData } from "discordeno";
 
 type ErrorMessageInfo = CreateMessageTypes.errorMessageInfo | null;
 

--- a/src/libs/messages/createFailureMessage.ts
+++ b/src/libs/messages/createFailureMessage.ts
@@ -1,7 +1,7 @@
 import { Constants } from "@libs";
 import { millisecondChangeFormat } from "@utils";
-import { CreateMessage, InteractionCallbackData } from "discordeno";
 import { CreateMessageTypes } from "@router/types/createMessageTypes.ts";
+import { CreateMessage, InteractionCallbackData } from "discordeno";
 
 type FailureMessageInfo = CreateMessageTypes.failureMessageInfo | null;
 

--- a/src/libs/messages/createFailureMessage.ts
+++ b/src/libs/messages/createFailureMessage.ts
@@ -1,6 +1,6 @@
 import { Constants } from "@libs";
-import { millisecondChangeFormat } from "@utils";
 import { CreateMessageTypes } from "@router/types/createMessageTypes.ts";
+import { millisecondChangeFormat } from "@utils";
 import { CreateMessage, InteractionCallbackData } from "discordeno";
 
 type FailureMessageInfo = CreateMessageTypes.failureMessageInfo | null;

--- a/src/libs/messages/createProgressMessage.ts
+++ b/src/libs/messages/createProgressMessage.ts
@@ -1,6 +1,6 @@
 import { Constants } from "@libs";
-import { millisecondChangeFormat } from "@utils";
 import { CreateMessageTypes } from "@router/types/createMessageTypes.ts";
+import { millisecondChangeFormat } from "@utils";
 import { CreateMessage, InteractionCallbackData } from "discordeno";
 
 type ProgressMessageInfo = CreateMessageTypes.progressMessageInfo | null;

--- a/src/libs/messages/createProgressMessage.ts
+++ b/src/libs/messages/createProgressMessage.ts
@@ -1,7 +1,7 @@
 import { Constants } from "@libs";
 import { millisecondChangeFormat } from "@utils";
-import { CreateMessage, InteractionCallbackData } from "discordeno";
 import { CreateMessageTypes } from "@router/types/createMessageTypes.ts";
+import { CreateMessage, InteractionCallbackData } from "discordeno";
 
 type ProgressMessageInfo = CreateMessageTypes.progressMessageInfo | null;
 

--- a/src/libs/messages/createSuccessMessage.ts
+++ b/src/libs/messages/createSuccessMessage.ts
@@ -1,6 +1,6 @@
 import { Constants } from "@libs";
-import { unitChangeForByte, millisecondChangeFormat } from "@utils";
 import { CreateMessageTypes } from "@router/types/createMessageTypes.ts";
+import { unitChangeForByte, millisecondChangeFormat } from "@utils";
 import { CreateMessage, InteractionCallbackData } from "discordeno";
 
 type SuccessMessageInfo = CreateMessageTypes.successMessageInfo | null;

--- a/src/libs/messages/createSuccessMessage.ts
+++ b/src/libs/messages/createSuccessMessage.ts
@@ -1,7 +1,7 @@
 import { Constants } from "@libs";
 import { unitChangeForByte, millisecondChangeFormat } from "@utils";
-import { CreateMessage, InteractionCallbackData } from "discordeno";
 import { CreateMessageTypes } from "@router/types/createMessageTypes.ts";
+import { CreateMessage, InteractionCallbackData } from "discordeno";
 
 type SuccessMessageInfo = CreateMessageTypes.successMessageInfo | null;
 

--- a/src/router/messages/successMessage.ts
+++ b/src/router/messages/successMessage.ts
@@ -1,9 +1,9 @@
 import bot from "@bot/bot.ts";
+import { Messages, Constants } from "@libs";
+import { CreateMessageTypes } from "@router/types/createMessageTypes.ts";
 import { Match } from "functional";
 import { Message, Embed } from "discordeno";
 import type { FileContent, CreateMessage } from "discordeno";
-import { Messages, Constants } from "@libs";
-import { CreateMessageTypes } from "@router/types/createMessageTypes.ts";
 
 type SingleSuccsessMessageObject =
   CreateMessageTypes.SendSuccessMessage.singleFileObject | null;


### PR DESCRIPTION
## Summary

Coding-guidelines Rule 1 (Imports & Aliases) compliance — 8 non-original-author files had external library imports appearing before local alias imports. Reordered to the canonical `local → external` convention. Zero behavior change.

## Files changed

| File | Change |
|------|--------|
| `src/bot/runThreadFlow.ts` | `@libs` moved before `functional`/`ky`/`discordeno` |
| `src/bot/threadModalSubmit.ts` | `@libs`, `@bot/` moved before `discordeno` |
| `src/libs/contents/multiFilesContent.ts` | `@libs/...`, `@router/...` moved before `discordeno` |
| `src/libs/messages/createSuccessMessage.ts` | `@router/...` moved before `discordeno` |
| `src/libs/messages/createProgressMessage.ts` | same |
| `src/libs/messages/createErrorMessage.ts` | same |
| `src/libs/messages/createFailureMessage.ts` | same |
| `src/router/messages/successMessage.ts` | `@libs`, `@router/` moved before `functional`/`discordeno`; split `import`/`import type` for discordeno kept but both in external block |

**Excluded (documented original-author deviations):** `src/bot/bot.ts`, `src/bot/interactionCreate.ts`, `src/router/callback.ts`.

## Before / After (representative)

```typescript
// src/bot/runThreadFlow.ts — Before
import { If } from "functional";
import { KyResponse } from "ky";
import { Bot, ChannelTypes, ... } from "discordeno";
import { Messages, Constants, isUrl, webhookThread } from "@libs";  // ❌ local after external

// After
import { Messages, Constants, isUrl, webhookThread } from "@libs";  // ✓ local first
import { If } from "functional";
import { KyResponse } from "ky";
import { Bot, ChannelTypes, ... } from "discordeno";
```

```typescript
// src/libs/messages/createSuccessMessage.ts — Before
import { Constants } from "@libs";
import { unitChangeForByte, millisecondChangeFormat } from "@utils";
import { CreateMessage, InteractionCallbackData } from "discordeno";  // ❌ external between locals
import { CreateMessageTypes } from "@router/types/createMessageTypes.ts";

// After
import { Constants } from "@libs";
import { unitChangeForByte, millisecondChangeFormat } from "@utils";
import { CreateMessageTypes } from "@router/types/createMessageTypes.ts";  // ✓ local last before external block
import { CreateMessage, InteractionCallbackData } from "discordeno";
```

## Coding-guidelines compliance

- **Rule 1 — Imports & Aliases**: All local aliases (`@bot/`, `@libs`, `@router/`, `@utils/`) now precede external library imports (`discordeno`, `functional`, `hono`, `ky`)

## Test plan

- [x] `deno lint` — passes on all 8 changed files
- [x] `deno task test` — 28 passed, 0 failed (144 steps)
- [x] No test changes required (import order has no runtime effect in Deno's ES module loader)

🤖 Generated with [Claude Code](https://claude.com/claude-code)