### PR TITLE
refactor(b4): move Modal constants to Constants object, camelCase local set (Rule 7)

### DIFF
--- a/src/bot/threadInteractionCreate.ts
+++ b/src/bot/threadInteractionCreate.ts
@@ -1,3 +1,4 @@
+import { Constants } from "@libs";
 import {
   Bot,
   Interaction,
@@ -13,26 +14,6 @@ type InteractionOption = Exclude<
 >[number];
 
 const NAME_OPTION = "name";
-
-/**
- * customId conventions used by the thread Modal flow.
- *
- * The wire format is:
- *
- *     <commandType>|<threadName-truncated-to-MAX_NAME_IN_CUSTOM_ID>
- *
- * Discord caps `customId` at 100 characters. Today the longest commandType
- * is `"threaddl-spoiler"` (16 chars) plus the `|` separator (1 char), so we
- * leave 80 chars of room for the thread name to be safe across both
- * `/threaddl` and `/threaddl-spoiler`.
- *
- * Truncation here only affects what we round-trip via `customId`. The Modal
- * `title` (and the actual thread name we hand to `startThreadWithoutMessage`)
- * use the same truncated value so what the user sees, what gets created on
- * Discord, and what we route on the callback are all consistent.
- */
-export const MAX_NAME_IN_CUSTOM_ID = 80;
-export const URLS_INPUT_CUSTOM_ID = "urls";
 
 /**
  * Resolves a string-typed option from the interaction data by name.
@@ -62,6 +43,12 @@ const pickOption = (
  * make the Modal impossible. So this handler returns the Modal immediately,
  * and the ModalSubmit handler is the one that ACKs + does the work.
  *
+ * customId wire format: `<commandType>|<threadName>` where threadName is
+ * truncated to `Constants.Modal.MAX_NAME_IN_CUSTOM_ID` characters.
+ * Discord caps `customId` at 100 chars; the longest commandType
+ * (`"threaddl-spoiler"`, 16 chars) plus the `|` separator (1 char) leaves
+ * 80 chars for the thread name, matching the constant value.
+ *
  * @param props - The handler props bag.
  * @param props.b - The bot instance.
  * @param props.data - The interaction data object.
@@ -76,7 +63,10 @@ export const threadInteractionCreate = async (props: {
   commandType: string;
 }): Promise<void> => {
   const rawName: string = pickOption(props.data.options, NAME_OPTION);
-  const threadName: string = rawName.slice(0, MAX_NAME_IN_CUSTOM_ID);
+  const threadName: string = rawName.slice(
+    0,
+    Constants.Modal.MAX_NAME_IN_CUSTOM_ID,
+  );
 
   await props.b.helpers.sendInteractionResponse(
     props.interaction.id,
@@ -92,7 +82,7 @@ export const threadInteractionCreate = async (props: {
             components: [
               {
                 type: MessageComponentTypes.InputText,
-                customId: URLS_INPUT_CUSTOM_ID,
+                customId: Constants.Modal.URLS_INPUT_CUSTOM_ID,
                 style: TextStyles.Paragraph,
                 label: "Tweet URLs",
                 placeholder:

--- a/src/bot/threadModalSubmit.ts
+++ b/src/bot/threadModalSubmit.ts
@@ -1,5 +1,5 @@
-import { Constants } from "@libs";
 import { runThreadFlow } from "@bot/runThreadFlow.ts";
+import { Constants } from "@libs";
 import { Bot, Interaction } from "discordeno";
 
 type InteractionData = Exclude<Pick<Interaction, "data">["data"], undefined>;

--- a/src/bot/threadModalSubmit.ts
+++ b/src/bot/threadModalSubmit.ts
@@ -1,7 +1,6 @@
-import { Bot, Interaction } from "discordeno";
 import { Constants } from "@libs";
 import { runThreadFlow } from "@bot/runThreadFlow.ts";
-import { URLS_INPUT_CUSTOM_ID } from "@bot/threadInteractionCreate.ts";
+import { Bot, Interaction } from "discordeno";
 
 type InteractionData = Exclude<Pick<Interaction, "data">["data"], undefined>;
 type InteractionDataComponents = Exclude<
@@ -15,23 +14,24 @@ type InteractionDataComponents = Exclude<
  * the sense that an arbitrary client could submit a forged ModalSubmit, so
  * we never trust the prefix and only match exact known commandTypes.
  */
-const ACCEPTED_COMMAND_TYPES = new Set<string>([
+const acceptedCommandTypes = new Set<string>([
   Constants.Webhook.Json.ClientPayload.CommandType.THREAD_DOWNLOAD,
   Constants.Webhook.Json.ClientPayload.CommandType.THREAD_DOWNLOAD_SPOILER,
 ]);
 
 /**
  * Walks the (ActionRow → InputText) component tree and pulls the `value`
- * field out of the InputText whose `customId === "urls"`. Returns `""` if
- * the tree shape doesn't match (defensive — shouldn't happen with a Modal
- * we built ourselves, but a forged ModalSubmit could).
+ * field out of the InputText whose `customId` matches
+ * `Constants.Modal.URLS_INPUT_CUSTOM_ID`. Returns `""` if the tree shape
+ * doesn't match (defensive — shouldn't happen with a Modal we built
+ * ourselves, but a forged ModalSubmit could).
  */
 const extractUrlsFieldValue = (
   components: InteractionDataComponents | undefined,
 ): string => {
   for (const row of components ?? []) {
     for (const child of row.components ?? []) {
-      if (child.customId === URLS_INPUT_CUSTOM_ID) {
+      if (child.customId === Constants.Modal.URLS_INPUT_CUSTOM_ID) {
         return child.value ?? "";
       }
     }
@@ -69,7 +69,7 @@ export const threadModalSubmit = async (props: {
   if (sepIdx <= 0) return;
 
   const commandType: string = customId.slice(0, sepIdx);
-  if (!ACCEPTED_COMMAND_TYPES.has(commandType)) return;
+  if (!acceptedCommandTypes.has(commandType)) return;
 
   const threadName: string = customId.slice(sepIdx + 1);
   const text: string = extractUrlsFieldValue(props.data.components);

--- a/src/libs/constants.ts
+++ b/src/libs/constants.ts
@@ -93,4 +93,8 @@ export const Constants = {
     BAD_REQUEST: 400,
     INTERNAL_SERVER_ERROR: 500,
   },
+  Modal: {
+    MAX_NAME_IN_CUSTOM_ID: 80,
+    URLS_INPUT_CUSTOM_ID: "urls",
+  },
 } as const satisfies Readonly<Record<string, unknown>>;

--- a/tests/bot/threadInteractionCreate.test.ts
+++ b/tests/bot/threadInteractionCreate.test.ts
@@ -7,8 +7,8 @@ import {
   MessageComponentTypes,
   TextStyles,
 } from "discordeno";
-import { Constants } from "../../src/libs/constants.ts";
-import { threadInteractionCreate } from "../../src/bot/threadInteractionCreate.ts";
+import { Constants } from "@libs";
+import { threadInteractionCreate } from "@bot/threadInteractionCreate.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnySpy = Spy<unknown, any[], any>;

--- a/tests/bot/threadInteractionCreate.test.ts
+++ b/tests/bot/threadInteractionCreate.test.ts
@@ -7,11 +7,8 @@ import {
   MessageComponentTypes,
   TextStyles,
 } from "discordeno";
-import {
-  MAX_NAME_IN_CUSTOM_ID,
-  threadInteractionCreate,
-  URLS_INPUT_CUSTOM_ID,
-} from "../../src/bot/threadInteractionCreate.ts";
+import { Constants } from "../../src/libs/constants.ts";
+import { threadInteractionCreate } from "../../src/bot/threadInteractionCreate.ts";
 
 // deno-lint-ignore no-explicit-any
 type AnySpy = Spy<unknown, any[], any>;
@@ -83,7 +80,7 @@ Deno.test("threadInteractionCreate (Modal opener)", async (t) => {
 
       const input = row.components[0];
       assertEquals(input.type, MessageComponentTypes.InputText);
-      assertEquals(input.customId, URLS_INPUT_CUSTOM_ID);
+      assertEquals(input.customId, Constants.Modal.URLS_INPUT_CUSTOM_ID);
       assertEquals(input.style, TextStyles.Paragraph);
       assertEquals(input.required, true);
       assertEquals(input.minLength, 1);
@@ -133,7 +130,7 @@ Deno.test("threadInteractionCreate (Modal opener)", async (t) => {
       // commandType prefix + separator + truncated name
       assertEquals(
         payload.data.customId,
-        `threaddl|${"A".repeat(MAX_NAME_IN_CUSTOM_ID)}`,
+        `threaddl|${"A".repeat(Constants.Modal.MAX_NAME_IN_CUSTOM_ID)}`,
       );
     },
   );


### PR DESCRIPTION
## Summary

Coding-guidelines Rule 7 (Naming Conventions) compliance — SCREAMING_SNAKE_CASE identifiers that lived outside the central `Constants` object are either moved in or renamed to camelCase. Zero behavior change.

## Changes

### `src/libs/constants.ts` — new `Modal` namespace
```typescript
// Added
Modal: {
  MAX_NAME_IN_CUSTOM_ID: 80,
  URLS_INPUT_CUSTOM_ID: "urls",
},
```

### `src/bot/threadInteractionCreate.ts`
| Before | After |
|--------|-------|
| `export const MAX_NAME_IN_CUSTOM_ID = 80;` | removed; consumers use `Constants.Modal.MAX_NAME_IN_CUSTOM_ID` |
| `export const URLS_INPUT_CUSTOM_ID = "urls";` | removed; consumers use `Constants.Modal.URLS_INPUT_CUSTOM_ID` |
| discordeno-only imports (external-first) | `@libs` import added first (Rule 1) |
| block comment explaining truncation logic | moved into JSDoc of `threadInteractionCreate` |

### `src/bot/threadModalSubmit.ts`
| Before | After |
|--------|-------|
| `import { URLS_INPUT_CUSTOM_ID } from "@bot/threadInteractionCreate.ts"` | removed |
| `const ACCEPTED_COMMAND_TYPES = new Set(...)` | `const acceptedCommandTypes = new Set(...)` (camelCase) |
| `child.customId === URLS_INPUT_CUSTOM_ID` | `child.customId === Constants.Modal.URLS_INPUT_CUSTOM_ID` |
| `ACCEPTED_COMMAND_TYPES.has(commandType)` | `acceptedCommandTypes.has(commandType)` |
| external-first imports | local-first (Rule 1) |

### `tests/bot/threadInteractionCreate.test.ts`
| Before | After |
|--------|-------|
| `import { MAX_NAME_IN_CUSTOM_ID, URLS_INPUT_CUSTOM_ID } from "...threadInteractionCreate.ts"` | `import { Constants } from "...constants.ts"` |
| `URLS_INPUT_CUSTOM_ID` (L86) | `Constants.Modal.URLS_INPUT_CUSTOM_ID` |
| `MAX_NAME_IN_CUSTOM_ID` (L136) | `Constants.Modal.MAX_NAME_IN_CUSTOM_ID` |

## Coding-guidelines compliance

- **Rule 7 — Naming Conventions**: SCREAMING_SNAKE_CASE now used only for values inside the central `Constants` object (as exempted by the guideline); file-local `Set` renamed to camelCase
- **Rule 1 — Imports**: `threadInteractionCreate.ts` and `threadModalSubmit.ts` import order fixed to local-first (bonus fix)

## Test plan

- [x] `deno lint` — passes on changed source files
- [x] `deno task test` — 28 passed, 0 failed (144 steps); `threadInteractionCreate.test.ts` steps verify `Constants.Modal.URLS_INPUT_CUSTOM_ID` and `Constants.Modal.MAX_NAME_IN_CUSTOM_ID` values

🤖 Generated with [Claude Code](https://claude.com/claude-code)